### PR TITLE
test(terminal): pin process-boundary tests to /bin/sh

### DIFF
--- a/internal/terminal/agent_test.go
+++ b/internal/terminal/agent_test.go
@@ -24,6 +24,7 @@ func TestAdHocShellRunningAnAgentReadsItsTitle(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub agent is a POSIX shell script")
 	}
+	useTestShell(t)
 
 	// A stub `claude` on PATH: paint the working glyph, hold it, then paint the
 	// idle marker and block so the tab stays live — exactly the shape of a turn.
@@ -94,6 +95,7 @@ func TestAdHocShellAgentReadsBlockedFromScreen(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub agent is a POSIX shell script")
 	}
+	useTestShell(t)
 
 	// A stub `claude`: paint the working glyph and hold (a turn), then switch the
 	// title to ✳ (idle — what a real permission prompt shows) while painting the Bash
@@ -170,6 +172,7 @@ func TestNonAgentCommandKeepsTheShellGrammar(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("foreground process groups are a unix affordance")
 	}
+	useTestShell(t)
 
 	m := NewManager(nil, nil)
 	term, err := m.Open("s1", t.TempDir())

--- a/internal/terminal/exit_test.go
+++ b/internal/terminal/exit_test.go
@@ -23,6 +23,8 @@ import (
 // So this asserts the primitive directly: a process that exits on its own makes
 // its terminal report dead, and the manager's onChange fires to publish it.
 func TestExitedProcessIsReaped(t *testing.T) {
+	useTestShell(t)
+
 	reaped := make(chan struct{}, 4)
 	m := NewManager(func() { reaped <- struct{}{} }, nil)
 	defer m.Shutdown()

--- a/internal/terminal/opener_test.go
+++ b/internal/terminal/opener_test.go
@@ -2,7 +2,9 @@ package terminal
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,18 +22,18 @@ import (
 // CR→NL translation cannot forge the byte under test.
 func TestTypedOpenerSubmitsWithCarriageReturn(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("the stub agent is a POSIX shell script")
+		t.Skip("the raw-mode stub requires POSIX stty")
 	}
 	shrinkOpenerTiming(t)
 
 	log := filepath.Join(t.TempDir(), "keystrokes.log")
-	agent := rawModeAgent(t, log)
+	agent, args, env := rawModeAgent(log)
 
 	m := NewManager(nil, nil)
 	defer m.Shutdown()
 
 	const opener = "Read the file /tmp/payload.md in full"
-	if _, err := m.OpenSession("space", t.TempDir(), "s1", agent, nil, nil, opener, Session{
+	if _, err := m.OpenSession("space", t.TempDir(), "s1", agent, args, env, opener, Session{
 		MapSlug: "m", TicketNum: 1, Role: "implement", Agent: "stub",
 	}, false); err != nil {
 		t.Fatalf("opening the session: %v", err)
@@ -47,17 +49,17 @@ func TestTypedOpenerSubmitsWithCarriageReturn(t *testing.T) {
 // must type nothing at all — not a stray return into a TUI that was already told.
 func TestEmptyOpenerTypesNothing(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("the stub agent is a POSIX shell script")
+		t.Skip("the raw-mode stub requires POSIX stty")
 	}
 	shrinkOpenerTiming(t)
 
 	log := filepath.Join(t.TempDir(), "keystrokes.log")
-	agent := rawModeAgent(t, log)
+	agent, args, env := rawModeAgent(log)
 
 	m := NewManager(nil, nil)
 	defer m.Shutdown()
 
-	if _, err := m.OpenSession("space", t.TempDir(), "s1", agent, nil, nil, "", Session{
+	if _, err := m.OpenSession("space", t.TempDir(), "s1", agent, args, env, "", Session{
 		MapSlug: "m", TicketNum: 1, Role: "implement", Agent: "stub",
 	}, false); err != nil {
 		t.Fatalf("opening the session: %v", err)
@@ -69,8 +71,8 @@ func TestEmptyOpenerTypesNothing(t *testing.T) {
 	}
 }
 
-// shrinkOpenerTiming collapses the readiness waits so a test that drives a stub
-// drawing nothing does not sit out the production grace period.
+// shrinkOpenerTiming collapses the readiness waits so the stub tests do not sit
+// out production-sized settle, grace, and submit intervals.
 func shrinkOpenerTiming(t *testing.T) {
 	t.Helper()
 	settle, grace, submit := openerSettle, openerGrace, openerSubmit
@@ -78,18 +80,42 @@ func shrinkOpenerTiming(t *testing.T) {
 	t.Cleanup(func() { openerSettle, openerGrace, openerSubmit = settle, grace, submit })
 }
 
-// rawModeAgent installs a stub agent that turns off the line discipline (as every
-// real TUI does) and copies its stdin verbatim to a log, so the test reads the
-// exact bytes chartr typed rather than the kernel's translation of them.
-func rawModeAgent(t *testing.T, log string) string {
-	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "stub-agent")
-	script := fmt.Sprintf("#!/bin/sh\nstty raw -echo 2>/dev/null\ncat >> %q\n", log)
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-		t.Fatalf("writing the stub agent: %v", err)
+const rawAgentLogEnv = "CHARTR_TEST_RAW_AGENT_LOG"
+
+// rawModeAgent relaunches this test binary as a stub agent. The child enters raw
+// mode and reads stdin itself, avoiding a shell between the stty call and the
+// reader that could restore terminal settings. Its invisible title is emitted
+// only after raw mode is active, giving awaitReady the same paint signal a real
+// TUI provides.
+func rawModeAgent(log string) (string, []string, []string) {
+	return os.Args[0], []string{"-test.run=^TestRawModeAgentProcess$"}, []string{rawAgentLogEnv + "=" + log}
+}
+
+func TestRawModeAgentProcess(_ *testing.T) {
+	log := os.Getenv(rawAgentLogEnv)
+	if log == "" {
+		return
 	}
-	return path
+
+	cmd := exec.Command("stty", "raw", "-echo")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "setting raw mode: %v\n", err)
+		os.Exit(2)
+	}
+
+	f, err := os.OpenFile(log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "opening keystroke log: %v\n", err)
+		os.Exit(2)
+	}
+	_, _ = fmt.Fprint(os.Stdout, "\x1b]0;ready\a")
+	if _, err := io.Copy(f, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "recording keystrokes: %v\n", err)
+		os.Exit(2)
+	}
+	_ = f.Close()
+	os.Exit(0)
 }
 
 func waitForFile(t *testing.T, path, want string, within time.Duration) string {

--- a/internal/terminal/opener_test.go
+++ b/internal/terminal/opener_test.go
@@ -27,7 +27,7 @@ func TestTypedOpenerSubmitsWithCarriageReturn(t *testing.T) {
 	shrinkOpenerTiming(t)
 
 	log := filepath.Join(t.TempDir(), "keystrokes.log")
-	agent, args, env := rawModeAgent(log)
+	agent, args, env := rawModeAgent(t, log)
 
 	m := NewManager(nil, nil)
 	defer m.Shutdown()
@@ -54,7 +54,7 @@ func TestEmptyOpenerTypesNothing(t *testing.T) {
 	shrinkOpenerTiming(t)
 
 	log := filepath.Join(t.TempDir(), "keystrokes.log")
-	agent, args, env := rawModeAgent(log)
+	agent, args, env := rawModeAgent(t, log)
 
 	m := NewManager(nil, nil)
 	defer m.Shutdown()
@@ -87,10 +87,16 @@ const rawAgentLogEnv = "CHARTR_TEST_RAW_AGENT_LOG"
 // reader that could restore terminal settings. Its invisible title is emitted
 // only after raw mode is active, giving awaitReady the same paint signal a real
 // TUI provides.
-func rawModeAgent(log string) (string, []string, []string) {
-	return os.Args[0], []string{"-test.run=^TestRawModeAgentProcess$"}, []string{rawAgentLogEnv + "=" + log}
+func rawModeAgent(t *testing.T, log string) (string, []string, []string) {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("finding test executable: %v", err)
+	}
+	return executable, []string{"-test.run=^TestRawModeAgentProcess$"}, []string{rawAgentLogEnv + "=" + log}
 }
 
+// This is not a real test. It is the helper process launched by rawModeAgent.
 func TestRawModeAgentProcess(_ *testing.T) {
 	log := os.Getenv(rawAgentLogEnv)
 	if log == "" {

--- a/internal/terminal/procstat_test.go
+++ b/internal/terminal/procstat_test.go
@@ -14,6 +14,8 @@ import (
 // command's name, and the change is observable — which is the whole basis for
 // the sidebar's live status indicator.
 func TestSampleTracksForegroundCommand(t *testing.T) {
+	useTestShell(t)
+
 	m := NewManager(nil, nil) // nil onChange: no background sampler, we drive sample() by hand
 	term, err := m.Open("s1", t.TempDir())
 	if err != nil {
@@ -38,6 +40,15 @@ func TestSampleTracksForegroundCommand(t *testing.T) {
 	if got := m.ForSpace("s1")[0].Proc; got != "sleep" {
 		t.Errorf("working shell proc = %q, want %q", got, "sleep")
 	}
+}
+
+// useTestShell keeps process-boundary tests independent of the operator's shell
+// startup files. Those tests need a prompt and foreground process groups, not the
+// user's plugins; a startup hook can briefly foreground its own command and make
+// the test observe that command instead of the one it just submitted.
+func useTestShell(t *testing.T) {
+	t.Helper()
+	t.Setenv("SHELL", "/bin/sh")
 }
 
 // waitStatus samples until the terminal reaches want or the deadline passes,


### PR DESCRIPTION
## The problem

Four process-boundary tests in `internal/terminal` fail on `main` for a developer whose shell startup file foregrounds a command. They pass in CI because CI's shell startup is empty.

On my machine (`$SHELL=/bin/zsh`, an `ssh-add` in the startup path), `main` fails deterministically — three runs, three identical failures:

```
--- FAIL: TestAdHocShellRunningAnAgentReadsItsTitle (0.37s)
    agent_test.go:64: foreground agent = "", want "claude" — identification never resolved the stub
--- FAIL: TestAdHocShellAgentReadsBlockedFromScreen (5.18s)
    agent_test.go:144: shell never reached status "blocked"
--- FAIL: TestNonAgentCommandKeepsTheShellGrammar (0.19s)
    agent_test.go:194: tab proc = "ssh-add", want "sleep" — the shell grammar names the command
--- FAIL: TestTypedOpenerSubmitsWithCarriageReturn (5.01s)
    opener_test.go:40: keystrokes.log never contained "...\r"; got "...\n"
--- FAIL: TestSampleTracksForegroundCommand (0.16s)
    procstat_test.go:39: working shell proc = "ssh-add", want "sleep"
```

`tab proc = "ssh-add", want "sleep"` is the shell-startup bug in one line. The process-boundary tests assert on the *foreground process* of a shell they just drove. They spawn the developer's `$SHELL`, so a startup hook that briefly foregrounds its own command wins the race and the test samples that instead of the command it submitted. Nothing is wrong with the code under test — the fixture is reading someone else's process.

`TestTypedOpenerSubmitsWithCarriageReturn` is a separate timing problem and does not use `$SHELL`. The old raw-mode stub provided no readiness signal, so opener submission relied on a fixed grace period before `stty raw` was active. The revised helper emits readiness only after entering raw mode, turning `awaitReady` into an explicit handshake instead of a timing assumption.

## The change

- `useTestShell(t)` — a two-line helper that pins the affected tests to `/bin/sh` via `t.Setenv`. Process-boundary tests need a prompt and foreground process groups, not the operator's plugins.
- `rawModeAgent(t, log) string` → `rawModeAgent(t, log) (agent, args, env)`. The stub relaunches the test executable via `os.Executable()`, carries its own argv and environment, enters raw mode, and then signals readiness before reading stdin.
- Two `t.Skip` reasons corrected: the raw-mode tests skip on Windows because the stub needs POSIX `stty`, not because it "is a POSIX shell script" — the shell script reason belongs to the agent tests, and the two had been copy-pasted together.

Tests only. No production code is touched.

## Result

Same two tests, same machine, before and after:

![before and after](https://vhs.charm.sh/vhs-8OmyyW3uGQl70MOWI2IRO.gif)

On this machine, bypassing the custom zsh startup also reduced three runs of the full package from about 12 seconds to about 4 seconds. This is a machine-local effect of that shell startup, not a general performance claim:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `main` | 12.46s **FAIL** | 12.28s **FAIL** | 12.26s **FAIL** |
| this PR | 4.10s ok | 4.03s ok | 3.96s ok |

Verified with repeated focused terminal tests (`-count=5`), a precompiled `go test -c` binary, `go test ./...`, `go vet ./...`, and `git diff --check`.
