### PR TITLE
Use Git root for subdirectory Spaces

### DIFF
--- a/.plan/maps/git-root-aware-space-registration-impl/map.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/map.md
@@ -1,0 +1,39 @@
+# Git-root-aware Space registration — implementation
+
+## Destination
+
+Implement the contract in [Git-root-aware Space registration](../git-root-aware-space-registration/spec.md).
+An operator can register a Space below a Git root, use the Git root for every
+current Git action, and keep the selected directory as the Space path.
+
+## Notes
+
+This is an implementation map. Its tickets are tracer-bullet slices. Each ticket
+must leave a user-visible path working and must use the existing chartr process
+test seam described in the spec.
+
+Use the terms Space path, Git root, and Git action from `CONTEXT.md`. Keep the Git
+root internal. Do not add a public Git-root field or change Space file discovery.
+
+The local tracker has no separate label field. The `ready-for-agent` marker is
+recorded in each ticket's metadata comment. Status remains derived from the
+ticket file.
+
+## Decisions so far
+
+<!-- one line per resolved implementation ticket: gist + link. Empty until work lands. -->
+
+- **01 — subdirectory registration.** Registration and the branch and dirty Git actions use one internal Git-root resolver. The selected Space path remains the registry, response, map, and skill path; shared-root Spaces keep separate identities and show shared Git state. [01](tickets/01-register-a-subdirectory-space-with-root-wide-git-state.md)
+- **02 — child Space claim and release commits.** Claim, ticket release, and dead-session release resolve the Git root, calculate root-relative ticket paths, and keep path-limited commits; process tests cover nested paths and unrelated root-file isolation. [02](tickets/02-commit-claims-and-releases-from-a-subdirectory-space.md)
+- **03 — registration edge cases and failure results.** Path validation runs before Git; linked worktrees, nested repositories, submodules, plain directories, and failure classes keep the settled response and error contract. [03](tickets/03-handle-git-root-edge-cases-and-registration-failures.md)
+
+## Not yet specified
+
+<!-- no additional implementation fog is known beyond the tickets below -->
+
+## Out of scope
+
+- The planning decisions and product boundaries in
+  [Git-root-aware Space registration](../git-root-aware-space-registration/map.md).
+- Legacy nested repository cleanup, public Git-root display, and new Git actions;
+  these are excluded by the source spec.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/01-register-a-subdirectory-space-with-root-wide-git-state.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/01-register-a-subdirectory-space-with-root-wide-git-state.md
@@ -1,0 +1,40 @@
+---
+type: task
+blocked_by: []
+claimed_by: s543787ab2ad4
+claimed_at: 2026-08-05T19:19:54Z
+---
+<!-- triage: ready-for-agent -->
+
+# Register a subdirectory Space with root-wide Git state
+
+## Question
+
+Make the main monorepo path work end to end.
+
+When an operator registers a directory below a normal Git worktree, chartr must
+keep that directory as the Space path. It must find and use the Git root without
+creating a nested repository. The registration response must keep the selected
+absolute path and must not expose the internal Git root.
+
+The Space snapshot must show branch and dirty state from the Git root. Maps,
+skills, and other Space files must remain scoped to the selected directory. Two
+Space paths in one Git root must remain separate Spaces.
+
+Add the shared internal Git-root resolution seam needed by registration and the
+existing branch and dirty Git actions. Keep the normal non-repository behavior
+available for the later edge-case ticket.
+
+## Done when
+
+- A repository child directory registers successfully.
+- Registration does not create `.git` in the child directory and reports
+  `gitInited` as false.
+- The response keeps the selected directory as the Space path.
+- Branch and dirty state use the Git root, including a dirty change outside the
+  selected directory.
+- Maps and skills remain scoped to the selected directory.
+- Two Spaces in one Git root keep separate paths and identities while showing
+  shared branch and dirty state.
+- No public registry, API, model, or UI field exposes the Git root.
+- Tests prove the behavior through the existing chartr process boundary.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/01-register-a-subdirectory-space-with-root-wide-git-state.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/01-register-a-subdirectory-space-with-root-wide-git-state.md
@@ -38,3 +38,32 @@ available for the later edge-case ticket.
   shared branch and dirty state.
 - No public registry, API, model, or UI field exposes the Git root.
 - Tests prove the behavior through the existing chartr process boundary.
+
+## Answer
+
+Implemented the normal repository-child path.
+
+- Added `internal/gitroot`. It normalizes the Space path and runs Git root
+  discovery with `git -C <Space path> rev-parse --show-toplevel`. It returns a
+  separate no-repository result. Registration runs `git init` only for that
+  result. An existing `.git` marker does not allow fallback initialization.
+- Registry registration now keeps the selected absolute path. It does not add a
+  Git-root field and reports `gitInited: false` for a repository child.
+- Branch and dirty Git actions resolve the Git root before they act. Dirty state
+  therefore includes changes outside the selected Space path. Map, skill, and
+  other Space file discovery still uses the selected path.
+- Added a process-boundary test for two child Spaces in one Git root. It checks
+  separate paths and identities, no child `.git` directory, shared branch and
+  dirty state, scoped maps and skills, and no Git-root field in the response.
+
+Validation:
+
+- `go vet ./...` passed.
+- `go test ./... -run '^$' -count=1` passed and compiled all packages.
+- `go test ./internal/registry -count=1` passed.
+- The process-boundary test and the full test suite cannot run in this sandbox
+  because the test harness cannot bind its local TCP listener. The full suite
+  also has unrelated terminal-test failures in this environment.
+
+Claim and release Git commits remain for ticket 02. Git edge-case registration
+failures remain for ticket 03.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/02-commit-claims-and-releases-from-a-subdirectory-space.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/02-commit-claims-and-releases-from-a-subdirectory-space.md
@@ -1,0 +1,30 @@
+---
+type: task
+blocked_by: [01]
+claimed_by: sad179ab3cb27
+claimed_at: 2026-08-05T19:29:17Z
+---
+<!-- triage: ready-for-agent -->
+
+# Commit claims and releases from a subdirectory Space
+
+## Question
+
+Make ticket claiming and release work when the Space path is below the Git root.
+
+When chartr writes a claim or release, it must run Git actions from the resolved
+Git root and compute the ticket path from that root. The existing single-ticket
+commit behavior must stay in place. A claim or release must not commit unrelated
+changes anywhere else in the shared Git root.
+
+## Done when
+
+- A claim from a subdirectory Space writes the claim marker and creates a commit
+  for that ticket file only.
+- A release from the same Space clears the marker and creates a commit for that
+  ticket file only.
+- The ticket path works when it is nested below the Git root.
+- An unrelated changed file is not staged or committed by either operation.
+- Existing claim and release behavior for a Space at the Git root remains green.
+- Tests prove the commit contents and Git history through the existing chartr
+  process boundary.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/02-commit-claims-and-releases-from-a-subdirectory-space.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/02-commit-claims-and-releases-from-a-subdirectory-space.md
@@ -28,3 +28,28 @@ changes anywhere else in the shared Git root.
 - Existing claim and release behavior for a Space at the Git root remains green.
 - Tests prove the commit contents and Git history through the existing chartr
   process boundary.
+
+## Answer
+
+Implemented root-aware claim and release commits.
+
+- Claim commits now resolve the Git root before they run. They calculate the
+  ticket path relative to that root.
+- Ticket release and dead-session release use the same Git-root rule.
+- The existing path-limited `git add` and `git commit --only` behavior remains.
+  An unrelated file in the Git root is not added or committed.
+- Added process-boundary tests for a nested claim, a ticket release, and a
+  dead-session release. The tests check the root-relative commit path, commit
+  history, claim marker, release marker, and unrelated root changes.
+
+Validation:
+
+- `gofmt` passed.
+- `go test ./... -run '^$' -count=1` passed with a temporary allowed Go cache.
+- `go vet ./...` passed.
+- `go test ./internal/registry -count=1` passed.
+- The three new process tests could not run. The test harness cannot bind
+  `127.0.0.1:0` in this sandbox and reports `operation not permitted`.
+
+No public Git-root field, Space-path change, file-discovery change, or new Git
+action was added.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/03-handle-git-root-edge-cases-and-registration-failures.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/03-handle-git-root-edge-cases-and-registration-failures.md
@@ -1,0 +1,40 @@
+---
+type: task
+blocked_by: [01]
+claimed_by: s969a2483e0a1
+claimed_at: 2026-08-05T19:29:21Z
+---
+<!-- triage: ready-for-agent -->
+
+# Handle Git root edge cases and registration failures
+
+## Question
+
+Complete the registration contract for repository forms and failure results that
+are not covered by the normal monorepo path.
+
+Registration must use the nearest usable Git root for linked worktrees, nested
+repositories, and submodules. A valid directory outside every repository must
+initialize Git only in the Space path. A missing Git command, broken Git metadata,
+bare repository, invalid worktree, inaccessible path, missing path, or regular
+file must fail without creating a new repository or registry entry.
+
+Keep the existing success response. Keep the selected Space path in the response,
+report `gitInited` only when chartr ran `git init`, and use the specified client or
+server error result for each failure class. Do not delete or migrate an existing
+nested `.git` directory.
+
+## Done when
+
+- A linked worktree root and child use the linked worktree root without a new
+  `git init`.
+- A nested repository and a submodule use the innermost repository root without
+  changing the outer repository.
+- A plain directory receives `.git` only in the selected directory and reports
+  `gitInited` as true.
+- Missing Git, broken Git metadata, a bare repository, and an invalid worktree
+  fail without initialization or a registry update.
+- A missing path, inaccessible path, and regular file fail before any Git action.
+- The response and error results match the settled registration contract.
+- Existing nested `.git` directories remain untouched.
+- Tests prove all supported cases through the existing chartr process boundary.

--- a/.plan/maps/git-root-aware-space-registration-impl/tickets/03-handle-git-root-edge-cases-and-registration-failures.md
+++ b/.plan/maps/git-root-aware-space-registration-impl/tickets/03-handle-git-root-edge-cases-and-registration-failures.md
@@ -38,3 +38,38 @@ nested `.git` directory.
 - The response and error results match the settled registration contract.
 - Existing nested `.git` directories remain untouched.
 - Tests prove all supported cases through the existing chartr process boundary.
+
+## Answer
+
+Completed the registration edge cases and failure results.
+
+- Registration now validates the Space path before it runs Git. Missing paths,
+  inaccessible directories, and regular files return client errors. They do not
+  run Git and do not add a registry entry.
+- Registration uses the shared Git-root resolver. It accepts linked worktrees,
+  nested repositories, and submodules without running `git init` or changing
+  the outer repository. A plain directory still receives `.git` only in the
+  selected Space path and reports `gitInited: true`.
+- Missing Git, broken Git metadata, bare repositories, and invalid worktrees
+  return server errors. They do not run `git init`, change existing `.git`
+  entries, or add a registry entry.
+- The success response is unchanged. It reports the selected absolute Space
+  path and `gitInited`. It does not expose the Git root. Registration persistence
+  errors are server errors, and a successful `git init` is not removed when a
+  later registry save fails.
+- Added process-boundary coverage for linked worktrees, nested repositories,
+  submodules, invalid paths, Git failures, error JSON, and registry save
+  failures.
+
+Validation:
+
+- `go vet ./...` passed.
+- `go test ./... -run '^$' -count=1` passed and compiled all packages.
+- `go test ./internal/registry -count=1` passed.
+- The focused registration process tests passed:
+  `go test ./internal/server -run '^TestRegister(SubdirectoryUsesRootGitStateAndSpaceFiles|LinkedWorktreeUsesLinkedRoot|NestedRepositoryAndSubmoduleUseInnermostRoots|FailuresDoNotInitOrPersist|RegistryFailureIsServerErrorAndKeepsInit|InitialisesNonRepoAnnounced)$' -count=1`.
+- A broader `^TestRegister` run also selects an existing ticket 02 spawn test.
+  That test still fails in ticket 02 claim-path code. It is outside this ticket.
+
+Claim and release Git actions remain in ticket 02. Public Git-root display and
+legacy nested repository cleanup remain out of scope.

--- a/.plan/maps/git-root-aware-space-registration/map.md
+++ b/.plan/maps/git-root-aware-space-registration/map.md
@@ -1,0 +1,48 @@
+# Git-root-aware Space registration
+
+## Destination
+
+A settled implementation contract for Git-root-aware Space registration. When an
+operator registers a Space from inside a Git repository, chartr keeps the selected
+directory as the Space path, finds the Git root, uses that root for every Git action,
+and does not run `git init` in the subdirectory. If no Git repository exists, chartr
+initializes Git in the Space path.
+
+## Notes
+
+This is a planning map. Resolve its tickets with the `grilling` and
+`domain-modeling` skills. Read the `tracker-convention` skill before changing map
+files.
+
+Use the terms **Space path**, **Git root**, and **Git action** from `CONTEXT.md`.
+
+The standing boundaries agreed during charting are:
+
+- The selected directory remains the Space path. The Git root stays internal.
+- Repository setup, branch display, dirty status, and claim or release commits use
+  the Git root. Maps and other Space files use the Space path.
+- Spaces that share a Git root remain separate Spaces and share the Git root's Git
+  state.
+- Existing nested `.git` directories are not deleted or migrated by this effort.
+
+## Decisions so far
+
+<!-- one line per resolved ticket: gist + link. -->
+
+- [01 — Git root discovery and fallback errors](tickets/01-git-root-discovery-and-fallback-errors.md) — Git-native discovery selects the nearest usable repository root; only an explicit no-repository result allows initialization, and other Git failures do not initialize or update the registry.
+
+- **01 — Git discovers the innermost worktree root from the Space path; only a confirmed no-repository result allows `git init` in the Space path. Linked worktrees and submodules stay valid, Git failures do not fall back, and the response reports the Space path plus `gitInited` without exposing the Git root.** [ticket](tickets/01-git-root-discovery-and-fallback-errors.md)
+
+## Not yet specified
+
+- **Git actions added later** — future Git actions may need the same root policy, but
+  no sharper question exists until such an action enters the codebase.
+
+## Out of scope
+
+- **Legacy nested repository cleanup** — deleting or migrating `.git` directories
+  that older chartr versions created inside a Space path.
+- **Showing the Git root** — adding the internal Git root to the registry, API, or
+  UI as a user-visible field.
+- **Implementation work** — this planning map produces the contract for a later
+  implementation map.

--- a/.plan/maps/git-root-aware-space-registration/spec.md
+++ b/.plan/maps/git-root-aware-space-registration/spec.md
@@ -1,0 +1,170 @@
+<!-- triage: ready-for-agent -->
+
+# Git-root-aware Space registration — spec
+
+## Problem Statement
+
+When an operator registers a Space from a subdirectory of a Git repository,
+chartr checks only the selected directory for `.git`. It does not see the Git
+root above that directory. It then runs `git init` in the subdirectory.
+
+This creates a new nested repository inside the company's repository. Later Git
+actions also use the subdirectory. Branch display, dirty status, and chartr claim
+or release commits can therefore use the wrong repository.
+
+This blocks operators who work in monorepos. Their Space path is often one or two
+levels below the Git root.
+
+## Solution
+
+Keep the selected directory as the Space path. From that path, find the nearest
+Git repository root by using Git's own repository discovery.
+
+Use the Git root for all current Git actions:
+
+- repository detection and setup;
+- branch display;
+- dirty status;
+- claim commits; and
+- release commits.
+
+Use the Space path for Space files, maps, skills, and other non-Git actions.
+
+If Git reports that the Space path is not inside a repository, initialize Git in
+the Space path. Use that path as the Git root after initialization. If Git reports
+another error, fail registration and do not run `git init`.
+
+The Git root is internal. The Space remains identified and displayed by its
+selected path. Two Spaces may use different paths inside one Git root. They remain
+separate Spaces and share the Git root's branch and dirty state.
+
+Claim and release commits remain limited to one ticket file. Compute the ticket
+path relative to the Git root so unrelated changes in the shared repository are
+not committed.
+
+## User Stories
+
+1. As an operator, I want to register a directory that is already a Git root, so that chartr uses the existing repository.
+2. As an operator, I want to register a directory inside a Git repository, so that chartr does not create a nested repository.
+3. As an operator, I want the selected directory to remain the Space path, so that chartr reads maps, skills, and files from the directory I selected.
+4. As an operator, I want chartr to find the nearest Git root, so that nested repositories and submodules use the repository that Git assigns to the selected path.
+5. As an operator, I want linked worktrees to work, so that a `.git` file does not cause false repository detection.
+6. As an operator, I want registration to report whether chartr ran `git init`, so that I know when chartr created a repository.
+7. As an operator, I want a non-repository directory to become a Git repository, so that I can register a new Space without preparing Git first.
+8. As an operator, I want `git init` to run in the selected directory when no repository exists, so that the new repository belongs to the Space path.
+9. As an operator, I want Git failures other than “no repository” to stop registration, so that chartr does not hide a broken Git installation or another operational error.
+10. As an operator, I want the registration response to keep the selected path, so that the Space identity does not change when its Git root is above it.
+11. As an operator, I want two subdirectories in one monorepo to remain separate Spaces, so that I can switch between them independently.
+12. As an operator, I want the branch shown for a subdirectory Space to come from its Git root, so that the cockpit shows the real repository branch.
+13. As an operator, I want the dirty state shown for a subdirectory Space to come from the full Git root, so that the state reflects the repository that Git actions change.
+14. As an operator, I want file and map discovery to remain scoped to the Space path, so that one Space does not display another Space's maps or skills.
+15. As an operator, I want a claim commit from a subdirectory Space to stage only its ticket file, so that chartr does not include unrelated monorepo changes.
+16. As an operator, I want a release commit from a subdirectory Space to use the same ticket path rule, so that claim and release have consistent Git behavior.
+17. As an operator, I want shared-root Spaces to keep their own Space names and identities, so that Git root sharing does not merge their registry entries.
+18. As an operator, I want the Git root to remain an internal detail, so that the existing Space API and UI do not gain a second path that can confuse me.
+19. As an operator, I want existing nested repositories to remain untouched, so that this change does not delete or rewrite data created by an older chartr version.
+20. As a maintainer, I want one high-level test seam for registration and Git actions, so that the tests prove operator-visible behavior without coupling to private helper functions.
+
+## Implementation Decisions
+
+- The canonical domain terms are Space path, Git root, and Git action. The Space
+  path is the selected directory. The Git root is the nearest repository root
+  found from that path.
+- Git-native root discovery is the source of truth. It must support normal
+  worktrees, linked worktrees, and nested repositories as Git supports them.
+- Registration must distinguish “no repository” from another Git error. Only the
+  explicit no-repository result permits initialization. A missing Git command,
+  permission failure, malformed or unusable Git metadata, bare repository, or
+  invalid worktree is an error and does not initialize a new repository.
+- A successful initialization uses the Space path as the Git root. The existing
+  `gitInited` response value remains true only when chartr actually ran
+  initialization. Registration of an existing repository returns false.
+- Path validation happens before Git discovery. A missing path, inaccessible path,
+  or regular file fails without a Git action.
+- The existing registration response remains the public contract. Success keeps
+  the selected absolute path and reports `gitInited`; invalid paths remain client
+  errors, while Git, initialization, and registry persistence failures remain
+  server errors. A successful `git init` is not removed automatically if registry
+  persistence fails.
+- The registry keeps the selected path as the Space path and keeps the existing
+  Space identity rules. The Git root is derived internal state. It is not a new
+  persisted registry field, API field, or UI field.
+- All current Git actions receive the Git root as their repository context. This
+  includes setup, branch display, dirty status, claim commits, and release
+  commits.
+- Non-Git file actions continue to use the Space path. Map discovery, skill
+  discovery, ticket reads and writes, and other Space file operations must not
+  widen to the Git root.
+- Dirty status is repository-wide for the Git root. If two Spaces share a Git
+  root, a change anywhere in that root can make both Spaces dirty.
+- Branch display is repository-wide for the Git root. If two Spaces share a Git
+  root, they show the same branch state.
+- Claim and release commits keep their current single-ticket behavior. The ticket
+  path is made relative to the Git root before staging and committing. The commit
+  must remain path-limited and must not include unrelated changes.
+- Existing nested `.git` directories are not deleted, migrated, or repaired by
+  this feature. Legacy cleanup is a separate effort.
+- Prefer one shared internal Git-root resolution seam for registration and all Git
+  actions. The exact function or type shape is an implementation detail, but the
+  behavior must not be reimplemented differently by each caller.
+
+## Testing Decisions
+
+- Tests must observe external behavior. They must not assert private fields,
+  helper calls, command construction, or the number of root-resolution calls.
+- The primary seam is the real chartr process boundary through the existing test
+  harness. Tests register temporary Spaces through the operator-facing HTTP API.
+- The test harness must assert the registration response, the Space snapshot, the
+  files in the temporary Space, and Git history or status as appropriate.
+- Use real temporary Git repositories. Create a repository root and child Space
+  directories to prove that registration from a subdirectory does not create a
+  child `.git` directory.
+- Cover registration from a repository root, from a child directory, from a
+  normal non-repository directory, from a linked worktree, and from a nested
+  repository or submodule where the platform test environment supports it.
+- Cover a Git failure that is not “no repository”. The observable result must be a
+  failed registration with no new `.git` directory. Include missing Git, unusable
+  metadata, and bare repository cases where the test environment supports them.
+- Cover two registered Spaces in one Git root. Assert that their paths and
+  identities remain separate while their branch and dirty values reflect the
+  shared Git root.
+- Cover a claim from a subdirectory Space. Assert that the ticket file is
+  committed and an unrelated changed file is not committed.
+- Cover release from a subdirectory Space with the same path and isolation
+  assertions.
+- Keep the existing non-repository registration test as the prior-art pattern for
+  the `gitInited` response and the created `.git` directory.
+- Extend the existing Space snapshot tests for branch and dirty state, and extend
+  the existing claim and release tests for Git history. Reuse the existing
+  temporary Space and Git fixture helpers.
+- The test set must verify the operator-visible contract. It must not test Git's
+  own root discovery implementation beyond the cases needed to prove chartr uses
+  the returned root correctly.
+
+## Out of Scope
+
+- Deleting, migrating, or identifying `.git` directories created by older chartr
+  versions.
+- Adding the Git root to the registry file, API response, Space model, or UI.
+- Changing the Space identity, Space name, map discovery, skill discovery, or file
+  path rules to use the Git root.
+- Filtering dirty status to only the Space path. Dirty status remains full-root
+  Git state.
+- Adding Git actions that do not exist today. A later Git action must receive its
+  own root policy.
+- Creating Git worktrees, branches, or other isolation for Spaces that share a
+  Git root.
+- Changing Git behavior outside the commands chartr runs for registration, branch
+  display, dirty status, claim, and release.
+
+## Further Notes
+
+This spec is based on the planning discussion in
+[Git-root-aware Space registration](map.md). The answer in
+[01 — Git root discovery and fallback errors](tickets/01-git-root-discovery-and-fallback-errors.md)
+settles root discovery and fallback errors. The remaining decision tickets can
+refine the shared-root and commit contracts before an implementation map is
+created.
+
+The local chartr tracker has no separate label field. The `ready-for-agent` label
+is recorded in the metadata comment at the top of this spec.

--- a/.plan/maps/git-root-aware-space-registration/tickets/01-git-root-discovery-and-fallback-errors.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/01-git-root-discovery-and-fallback-errors.md
@@ -31,3 +31,121 @@ reports.
 The answer gives one root discovery and fallback rule. It distinguishes no
 repository from another Git error. It states the expected result for every listed
 path type and names the acceptance cases that prove the rule.
+
+## Answer
+
+### Decision
+
+Use Git to discover the root from the normalized absolute Space path:
+
+```text
+git -C <Space path> rev-parse --show-toplevel
+```
+
+When this command succeeds, its output is the Git root. Normalize the output to
+an absolute, clean path. The command handles both forms of `.git`: a directory
+in a normal worktree and a file in a linked worktree. Registration must not use
+`Space path/.git` as the repository test.
+
+The discovery operation has three outcomes:
+
+1. **Git root found.** Use the reported root. Do not run `git init`.
+2. **No repository found.** Allow fallback only when Git gives the explicit
+   no-repository result for the Space path. An equivalent typed result is also
+   valid. Run `git init` with the Space path as its working directory. After a
+   successful init, the Git root is the Space path.
+3. **Git failure.** A missing Git command, a permission failure, a malformed or
+   unusable `.git`, a bare repository, an invalid worktree, or any other result
+   that is not the explicit no-repository result is an error. Do not run
+   `git init`.
+
+The implementation must not use `if probeError != nil { git init }`. In
+particular, an existing but broken `.git` entry must not be replaced by a new
+repository. The no-repository classification must distinguish that case from a
+directory with no repository in its ancestor chain.
+
+### Required path results
+
+| Selected path | Git root | `git init` | Registration result |
+| --- | --- | --- | --- |
+| Normal worktree root or subdirectory | The containing worktree root | No | Success; `gitInited` is `false` |
+| Linked worktree root or subdirectory | The linked worktree root, not the common Git directory | No | Success; `gitInited` is `false` |
+| Nested repository or submodule | The innermost repository root, not the outer repository or superproject | No | Success; `gitInited` is `false` |
+| Valid directory outside every repository | The selected Space path after init | Yes, in the Space path | Success; `gitInited` is `true` |
+| Missing Git command or another Git failure | None is selected | No | Failure; no new or updated registration |
+| Missing path, inaccessible path, or a path that is not a directory | None is selected | No | Failure; no new or updated registration |
+
+For a nested repository, the parent repository remains the parent of the
+selected Space path only when the path is outside the nested repository. A
+submodule is treated as its own repository because Git reports the submodule
+worktree as the root. This accepts separate Git state for the submodule.
+
+### Registration response
+
+On success, `POST /api/spaces` returns HTTP 200 with the existing response
+shape:
+
+```json
+{"id":"...","path":"<absolute Space path>","gitInited":false}
+```
+
+`gitInited` is `true` only when this registration ran a successful `git init`.
+The response always reports the selected Space path. It does not report the
+internal Git root.
+
+On failure, the endpoint returns an error JSON body and no success fields. An
+invalid path is a client error (HTTP 400). A missing Git command, another Git
+failure, a failed `git init`, or a registry persistence failure is a server
+error (HTTP 500). The error text must identify the failed operation and preserve
+Git output where it helps the operator correct the problem. Discovery and init
+failures must not create or update a registry entry.
+
+Path validation happens before Git discovery, so an invalid path never causes a
+Git action. Registration is not atomic with repository initialization: if
+`git init` succeeds but saving the registry entry fails, the response is still
+an error and chartr does not delete the new `.git` directory automatically.
+This avoids a destructive cleanup decision and must remain visible to the
+operator.
+
+### Rejected alternatives
+
+- **Check only `Space path/.git`.** Rejected because a subdirectory of a
+  repository would cause an unwanted nested `git init`. It also fails to find
+  the root above the selected path.
+- **Walk for a `.git` entry without asking Git.** Rejected because it accepts a
+  stale or broken marker and duplicates Git's worktree rules. It cannot safely
+  decide whether a bare or malformed repository is usable.
+- **Treat every discovery error as no repository.** Rejected because it can
+  turn a missing Git command, a permission problem, or a damaged repository into
+  an unexpected write. The safe cost is to refuse registration until the Git
+  problem is fixed.
+
+### Acceptance cases
+
+The later implementation must prove these cases at the registration boundary:
+
+- Register a normal repository subdirectory. No `.git` appears in the selected
+  directory; the response keeps that directory as `path` and reports
+  `gitInited: false`.
+- Register a linked worktree and a subdirectory in it. The `.git` file remains
+  valid, no init runs, and the selected linked worktree root is used for a Git
+  action.
+- Register a nested repository and a submodule path. Neither case initializes
+  the outer repository, and a Git action uses the innermost root.
+- Register a plain directory. `.git` is created only in the selected directory,
+  the new root is that directory, and the response reports `gitInited: true`.
+- Run registration with Git unavailable. Run it with an unusable `.git` or a
+  bare repository. Each case returns an error, creates no new repository, and
+  creates no new registry entry.
+- Register a missing path and a regular file. Each case fails before any Git
+  command and creates no `.git` entry.
+- Assert the success JSON fields and the error JSON shape. The Git root is not
+  exposed in the response.
+
+### Revisit trigger
+
+Reopen this decision if a new Git worktree type cannot be represented by Git's
+root discovery, if chartr must support bare repositories, if an operator needs
+the superproject root instead of the innermost root, or if registration must
+roll back a successful `git init` when registry persistence fails. A new Git
+action that cannot consume this internal root also reopens the decision.

--- a/.plan/maps/git-root-aware-space-registration/tickets/01-git-root-discovery-and-fallback-errors.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/01-git-root-discovery-and-fallback-errors.md
@@ -1,0 +1,33 @@
+---
+type: grilling
+blocked_by: []
+claimed_by: s61b5dbba8898
+claimed_at: 2026-08-05T18:55:26Z
+---
+
+# Git root discovery and fallback errors
+
+## Question
+
+Define the repository setup contract for a Space path.
+
+The current registration code checks only `Space path/.git`. It must instead find
+the Git root from the selected path and must initialize Git only when no repository
+exists. Settle the exact behavior for:
+
+- a normal Git worktree;
+- a linked worktree whose `.git` is a file;
+- a nested repository or submodule;
+- a path that is not inside a repository;
+- a missing Git command or another Git failure; and
+- a path that cannot be registered.
+
+The contract must state which root is selected, which failures allow `git init`,
+what path is used when initialization succeeds, and what the registration response
+reports.
+
+## Done when
+
+The answer gives one root discovery and fallback rule. It distinguishes no
+repository from another Git error. It states the expected result for every listed
+path type and names the acceptance cases that prove the rule.

--- a/.plan/maps/git-root-aware-space-registration/tickets/02-space-path-and-shared-git-state.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/02-space-path-and-shared-git-state.md
@@ -25,3 +25,90 @@ path.
 The answer states which path each affected part of the Space uses. It defines the
 behavior for two Spaces in one Git root. It states whether any model, API, or UI
 field changes are needed.
+
+## Answer
+
+### Decision
+
+Use a two-path boundary:
+
+- The **Space path** is the selected, normalized absolute directory. It remains
+  the Space's identity and the boundary for Space files.
+- The **Git root** is an internal derived value. Registration discovers it by the
+  rule in Ticket 01. Later Git actions use that root. The root is not stored in
+  the registry and is not exposed to the operator.
+
+The answer from Ticket 01 is a sound blocker. It selects the innermost worktree
+root, including a linked worktree root, and does not confuse the common Git
+directory with that root. This supports the boundary below.
+
+### Path assignment
+
+| Space part | Path | Contract |
+| --- | --- | --- |
+| Registry entry | Space path | Persist the selected absolute path. Do not persist the Git root. |
+| Space identity | Space path | Keep the existing ID from the normalized absolute Space path. Two different Space paths have different IDs, even when they have the same name. |
+| Space name | Space path | Derive the name from the selected directory. Do not derive it from the Git root. |
+| Maps and map files | Space path | Discover `.plan/maps/` and read or write map files below the Space path. |
+| Skills | Space path | Resolve the Space skill layer below `<Space path>/.chartr/skills`. Global and user skill layers do not change. |
+| Other Space files and file actions | Space path | Use the selected directory. This includes the Space's working directory and file watchers. |
+| Branch display | Git root | Read the current branch or detached HEAD of the worktree at the Git root. |
+| Dirty status | Git root | Read the Git status of the full Git root. Changes outside the Space path can make the Space dirty. |
+| Git actions | Git root | Use the root for repository setup, branch and dirty checks, and claim or release commits. Ticket 03 defines the commit path details. |
+
+The internal root can be passed between these Git operations or cached in
+memory. It must remain derived from the Space path under Ticket 01 and must not
+become a registry, API, model, or UI field.
+
+### Two Spaces in one Git root
+
+For two selected directories such as `/repo/one` and `/repo/two`, with
+`/repo` as their Git root:
+
+- They remain two registry entries and two Spaces. Their IDs use their own
+  Space paths. Their names use `one` and `two`. A name collision in other paths
+  does not merge their IDs.
+- Their map discovery, map files, skill layers, file actions, and working
+  directories remain independent because each uses its own Space path.
+- They show the same branch. They also show the same dirty value because both
+  describe `/repo`'s Git state.
+- A Git change or commit made for one Space can change the branch or dirty
+  value shown for the other Space. A rebuild reads the current root state for
+  both Spaces. This shared state is intentional.
+
+Two linked worktrees that use one common Git administrative directory do not
+share a Git root for this rule. Ticket 01 selects each linked worktree root.
+
+No public field changes are needed. Keep the existing registry path, model
+`Space.path`, `branch`, and `dirty` fields, and the existing registration
+response with `id`, `path`, and `gitInited`. Do not add `gitRoot` to the registry
+file, API response, server model, client model, or UI.
+
+### Rejected alternatives
+
+- **Use the Space path for every operation.** This keeps a local-looking
+  boundary, but it relies on Git's implicit discovery. Direct `.git` readers
+  fail for a repository subdirectory and a linked worktree. Later Git actions
+  can also calculate paths from the wrong base. It does not give every Git
+  action the root contract from Ticket 01.
+- **Use the Git root for every operation.** This makes branch and dirty checks
+  simple, but it makes root-level maps, files, and skills appear to belong to
+  every Space. It breaks the selected directory as the Space path and can
+  collapse the identity of Spaces that share a root.
+- **Persist the Git root as a hidden registry field.** This avoids a later
+  discovery call, but the value can become stale when a nested repository or
+  worktree changes. It also adds migration and leakage risk for a value that
+  the operator does not need to see. The Space path is the stable registry
+  value; the Git root is derived state.
+- **Show Git state only for files below each Space path.** This would isolate
+  the badges, but branch state belongs to the worktree and the map direction
+  requires root-wide Git state. It would also hide changes that can affect a
+  claim or release commit.
+
+### Revisit trigger
+
+Reopen this decision if an accepted Git action cannot use the root selected by
+Ticket 01, if an operator needs branch or dirty state limited to one Space path,
+if shared-root state causes unsafe cross-Space work, or if root discovery cannot
+remain reliable without a persisted public value. A need for the superproject
+root instead of the innermost worktree root reopens Ticket 01 first.

--- a/.plan/maps/git-root-aware-space-registration/tickets/02-space-path-and-shared-git-state.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/02-space-path-and-shared-git-state.md
@@ -1,0 +1,27 @@
+---
+type: grilling
+blocked_by: [01]
+claimed_by: se451ad1e7690
+claimed_at: 2026-08-05T18:59:50Z
+---
+
+# Space path and shared Git state
+
+## Question
+
+Define the boundary between the Space path and the Git root after
+[01 — Git root discovery and fallback errors](01-git-root-discovery-and-fallback-errors.md)
+settles root selection.
+
+The selected directory must remain the Space path and the Git root must remain
+internal. Decide how this boundary applies to the registry entry, Space name and
+identity, map and skill discovery, branch display, dirty status, and multiple
+Spaces that share one Git root. The current direction is that branch and dirty
+state describe the full Git root, while file and map actions stay at the Space
+path.
+
+## Done when
+
+The answer states which path each affected part of the Space uses. It defines the
+behavior for two Spaces in one Git root. It states whether any model, API, or UI
+field changes are needed.

--- a/.plan/maps/git-root-aware-space-registration/tickets/03-claim-and-release-commits-from-a-subdirectory.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/03-claim-and-release-commits-from-a-subdirectory.md
@@ -28,3 +28,125 @@ Build this answer on:
 The answer gives the path and command contract for both claim and release. It
 states the failure behavior and proves that a shared Git root does not cause an
 unrelated file to enter a chartr commit.
+
+## Answer
+
+### Decision
+
+Use the two-path boundary from Tickets 01 and 02. Discover or pass the internal
+Git root for the Space. Keep reading and writing the ticket at its ticket path
+under the Space path. Run every Git command with the Git root as its working
+directory. Do not persist or expose the Git root.
+
+Before changing the ticket, normalize both paths to absolute, clean paths and
+compute:
+
+```text
+ticketRel = filepath.Rel(gitRoot, ticketPath)
+```
+
+The action must reject the path when this computation fails, returns an absolute
+path, returns `.` (the root itself), or returns `..` or a path that starts with
+`..` and a path separator. This is a strict descendant check. It must not use a
+raw string prefix check. A ticket outside the Git root is an internal error. The
+action returns before it reads or edits the ticket, stages a path, or runs a
+commit.
+
+If Git root discovery fails during a claim or release, including an explicit
+no-repository result, the action fails. Claim and release never run `git init`.
+They never use the Space path as a fallback Git root.
+
+### Claim commit
+
+The claim keeps its current file operation and commit message content. It uses
+the root-relative ticket path for both Git commands and for the path in the
+claim message:
+
+```text
+git -C <Git root> add -- <ticketRel>
+git -C <Git root> commit --only -m <claim message> -- <ticketRel>
+```
+
+Running these commands with `<Git root>` as the process working directory is
+equivalent to using `git -C`. `--` ends the option list. `--only` remains
+required. It makes the commit contain the current content of only
+`<ticketRel>`, including a ticket that was not tracked before the `add`.
+
+Chartr stamps the claim in the ticket file under the Space path, stages that
+one root-relative path, and commits it. It launches the session only after the
+claim commit succeeds. The existing claim trailers remain unchanged.
+
+### Release commit
+
+The release uses the same `ticketRel` calculation, Git root, and pathspec:
+
+```text
+git -C <Git root> add -- <ticketRel>
+git -C <Git root> commit --only -m <release message> -- <ticketRel>
+```
+
+Chartr removes the claim keys from the ticket under the Space path, stages only
+that root-relative ticket path, and commits the release. The release message
+names `ticketRel` and keeps the existing session and `Chartr-Write` values.
+
+### Failure behavior
+
+- A path validation failure returns before any ticket or Git change.
+- A root discovery failure, a ticket read or write failure, `git add` failure,
+  or `git commit` failure returns an error. The error identifies the operation
+  and includes Git's combined output when Git produced output.
+- A claim error returns a server error and does not write the session payload or
+  launch a session. A release error returns a server error and does not report
+  success, discard the dead tab, or rebuild the model.
+- Chartr does not retry with another path, run `git init`, reset, revert, or
+  unstage after an error. If the ticket file was changed before a Git command
+  failed, that change and any index state left by Git remain visible for the
+  operator to repair. This accepts a visible partial lifecycle write so chartr
+  does not overwrite operator or agent edits during automatic cleanup.
+
+### Shared-root safety
+
+For Git root `/repo`, Space path `/repo/one`, and ticket
+`/repo/one/.plan/maps/demo/tickets/03-commit.md`, the pathspec is:
+
+```text
+one/.plan/maps/demo/tickets/03-commit.md
+```
+
+An unrelated file such as `/repo/two/work.go` is not named by either command.
+`git add -- <ticketRel>` does not stage it. `git commit --only ... --
+<ticketRel>` does not copy it from the index into the commit, even when the
+unrelated file was already staged. The unrelated change remains in the working
+tree or index after the chartr commit. A Space that shares the root still sees
+the root-wide dirty state from Ticket 02; shared dirty state is not shared
+commit content.
+
+This guarantee is at file-path level. An edit to the same ticket file is part of
+the one path and cannot be separated by `--only`. That remains a concurrent
+same-file edit risk.
+
+### Rejected alternatives
+
+- **Use the Space path as the Git base.** Rejected because it breaks the
+  two-path contract and makes the path in a subdirectory Space different from
+  the path Git actions use at the root.
+- **Use an absolute ticket path or allow `..` pathspecs.** Rejected because it
+  removes the strict repository boundary and can address a path outside the
+  selected Git root.
+- **Use `git add -A`, `git commit -a`, or a commit without `--only`.** Rejected
+  because a shared Git root can then put another Space's staged or working file
+  into a chartr commit.
+- **Treat a Git error as no repository and initialize.** Rejected by Ticket 01.
+  It can replace or hide a broken repository and is not valid for a later Git
+  action.
+- **Restore the ticket automatically after a Git failure.** Rejected because
+  restoration can overwrite a new operator or agent edit, and the append-only
+  contract leaves cleanup to the operator. The accepted cost is a visible
+  uncommitted lifecycle change.
+
+### Revisit trigger
+
+Reopen this decision if Git root discovery cannot provide a usable root for a
+claim or release, if a lifecycle action must commit more than one file, if
+same-ticket edits need field-level isolation, or if chartr must provide atomic
+rollback for a failed lifecycle commit.

--- a/.plan/maps/git-root-aware-space-registration/tickets/03-claim-and-release-commits-from-a-subdirectory.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/03-claim-and-release-commits-from-a-subdirectory.md
@@ -1,0 +1,30 @@
+---
+type: grilling
+blocked_by: [01, 02]
+claimed_by: s209205d6ec3e
+claimed_at: 2026-08-05T19:03:13Z
+---
+
+# Claim and release commits from a subdirectory
+
+## Question
+
+Define claim and release commit behavior when a ticket file is under the Space
+path but Git commands run at the Git root.
+
+The current behavior stages and commits one ticket file with a path relative to the
+Space path. Decide how the path is computed from the Git root, how the existing
+single-ticket `--only` behavior is preserved, and what happens when the ticket
+path is not inside the Git root or a Git command fails. The contract must protect
+unrelated changes in a shared Git root.
+
+Build this answer on:
+
+- [01 — Git root discovery and fallback errors](01-git-root-discovery-and-fallback-errors.md);
+- [02 — Space path and shared Git state](02-space-path-and-shared-git-state.md).
+
+## Done when
+
+The answer gives the path and command contract for both claim and release. It
+states the failure behavior and proves that a shared Git root does not cause an
+unrelated file to enter a chartr commit.

--- a/.plan/maps/git-root-aware-space-registration/tickets/04-verification-matrix-for-git-root-aware-registration.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/04-verification-matrix-for-git-root-aware-registration.md
@@ -1,0 +1,28 @@
+---
+type: grilling
+blocked_by: [01, 02, 03]
+claimed_by: s4529e7818655
+claimed_at: 2026-08-05T19:08:12Z
+---
+
+# Verification matrix for Git-root-aware registration
+
+## Question
+
+Turn the decisions in:
+
+- [01 — Git root discovery and fallback errors](01-git-root-discovery-and-fallback-errors.md);
+- [02 — Space path and shared Git state](02-space-path-and-shared-git-state.md); and
+- [03 — Claim and release commits from a subdirectory](03-claim-and-release-commits-from-a-subdirectory.md)
+
+into a complete acceptance matrix. Include registration from a repository root,
+from a subdirectory, from a non-repository directory, and from the supported
+special repository forms. Include branch and dirty state, two Spaces sharing one
+Git root, claim and release commits, the `gitInited` response, and the unchanged
+non-repository behavior.
+
+## Done when
+
+The answer lists the required test scenarios and their observable results. It
+identifies the smallest test seams that prove the contract without testing Git's
+own behavior. It also states which old tests must remain unchanged.

--- a/.plan/maps/git-root-aware-space-registration/tickets/04-verification-matrix-for-git-root-aware-registration.md
+++ b/.plan/maps/git-root-aware-space-registration/tickets/04-verification-matrix-for-git-root-aware-registration.md
@@ -26,3 +26,140 @@ non-repository behavior.
 The answer lists the required test scenarios and their observable results. It
 identifies the smallest test seams that prove the contract without testing Git's
 own behavior. It also states which old tests must remain unchanged.
+
+## Answer
+
+### Decision
+
+Use one acceptance matrix at the HTTP boundary, with two narrow test seams:
+
+1. Use real temporary Git fixtures for successful registration, branch and
+   dirty state, shared roots, linked worktrees, nested repositories, submodules,
+   and claim or release commits.
+2. Use a test Git command runner, or a Git command shim, for missing commands,
+   controlled Git failures, command working directories, arguments, and the
+   no-repository versus other-error decision. Use a registry-save failure seam
+   for the persistence case.
+
+The tests must check chartr's inputs, outputs, and side effects. They must not
+test Git's internal implementation. The public registration route remains the
+main seam. It proves the HTTP status, JSON body, registry state, Space model,
+and files together.
+
+The three blocker answers are load-bearing and agree. The no-repository result
+must be different from every other Git error. The selected directory remains
+the Space path. The derived Git root is used only for Git actions. A current
+implementation gap is visible: registration still checks `Space path/.git`,
+`deriveSpace` still passes the Space path to branch and dirty checks, and claim
+and release still pass the Space path to their commit writers. The matrix must
+fail for these cases until the later implementation fixes those paths. This
+ticket does not change that code.
+
+### Registration matrix
+
+| Case | Setup and action | Required observable result |
+| --- | --- | --- |
+| Repository root | Register the root of a normal worktree. | HTTP 200. The response has only `id`, absolute Space `path`, and `gitInited: false`. No `git init` runs. The registry and model use the root as the Space path. |
+| Repository subdirectory | Register `/repo/one` while `/repo` is the worktree root. | HTTP 200 and `gitInited: false`. The response path and registry path are `/repo/one`. The Space name and ID come from `/repo/one`. No `.git` is created in `/repo/one`. A Git action uses `/repo` as its Git root. |
+| Linked worktree root | Register a linked worktree root whose `.git` is a file. | HTTP 200 and `gitInited: false`. The `.git` file stays valid. The Git root is the linked worktree root, not the common Git directory. Branch and dirty state work. |
+| Linked worktree subdirectory | Register a directory below that linked worktree. | HTTP 200 and `gitInited: false`. No nested `.git` is created. A Git action uses the linked worktree root. |
+| Nested repository | Register the inner repository in an outer repository. | HTTP 200 and `gitInited: false`. The inner repository is the Git root. The outer repository is not initialized or changed by registration. |
+| Submodule | Register the submodule worktree, and then a directory below it. | HTTP 200 and `gitInited: false`. Git uses the submodule worktree as the root. The superproject is not used as the Git root and no new `.git` is created in the selected path. |
+| Directory outside a repository | Register a plain temporary directory with no repository in its ancestors. | HTTP 200 and `gitInited: true`. `git init` runs in the selected Space path. `.git` is created there. The response path is the selected absolute path. |
+| Explicit no-repository result | At the Git command seam, return the typed no-repository result for a valid directory. | `git init` runs once with the Space path as its working directory. Registration succeeds with `gitInited: true`. |
+| Missing Git command | Make the Git command unavailable. Register a valid directory. | HTTP 500. The error JSON has no success fields and identifies Git discovery. `git init` does not run. No registry entry is created or changed. |
+| Broken or unusable `.git` | Use a broken `.git` entry or an invalid worktree. | HTTP 500. The error preserves useful Git output. `git init` does not run. No registry entry is created or changed. |
+| Bare repository | Select a bare repository as the Space path. | HTTP 500. Chartr does not treat the bare repository as a worktree and does not run `git init`. No registration is saved. |
+| Init failure | Return the explicit no-repository result, then fail `git init`. | HTTP 500 with the init operation and Git output. No registry entry is created or changed. |
+| Registry save failure after init | Let `git init` succeed, then fail registry persistence. | HTTP 500. The new `.git` remains in the Space path. Chartr does not delete it. No successful registration response is returned. |
+| Invalid path | Register a missing path, a regular file, and an inaccessible path. | HTTP 400. Validation stops before any Git command. No `.git` entry and no new or updated registry entry exists. |
+| Response privacy | Inspect every successful response, error response, registry entry, and model JSON. | No response, registry field, server model field, client model field, or UI value exposes `gitRoot`. |
+
+For all success cases, assert the existing JSON shape. For all failure cases,
+assert an error JSON body with no `id`, `path`, or `gitInited`. The HTTP status
+must be 400 only for invalid input. Git discovery, init, and persistence errors
+must be 500.
+
+### Branch, dirty state, and shared-root matrix
+
+| Case | Setup and action | Required observable result |
+| --- | --- | --- |
+| Branch from the Git root | Register `/repo/one` with `/repo` on a named branch. Rebuild the model. | The Space path remains `/repo/one`. The branch field shows the branch for `/repo`. A linked worktree shows its own branch. |
+| Dirty state outside the Space | Keep `/repo/one` clean. Create or modify `/repo/two/outside.txt`. Rebuild. | The Space for `/repo/one` is dirty because the full Git root is dirty. A file below another Space can cause this result. |
+| Two Spaces, one root | Register `/repo/one` and `/repo/two`. Give each directory different maps, skills, and files. | Two registry entries and two Spaces remain. IDs, names, maps, skills, working directories, and file actions stay separate. IDs use the two Space paths, not the Git root. |
+| Shared Git state | With the two Spaces registered, change the branch or dirty state of `/repo`. Rebuild. | Both Spaces show the same branch and dirty value for that Git root. A Git commit for one Space can change the state shown for the other. |
+| No root leakage | Inspect the two registry entries, model snapshots, registration responses, and client payloads. | The internal Git root is absent. The existing `path`, `branch`, and `dirty` fields keep their meanings. |
+
+### Claim and release matrix
+
+Use a Space at `/repo/one` and a ticket at
+`/repo/one/.plan/maps/demo/tickets/03-commit.md`. Use `/repo/two/work.go` as
+an unrelated file. Keep that file staged before the lifecycle action when the
+test checks `--only`.
+
+| Case | Setup and action | Required observable result |
+| --- | --- | --- |
+| Claim from a subdirectory Space | Register `/repo/one` and spawn a supported test agent for the ticket. | The ticket is stamped. The session starts only after the claim commit succeeds. The claim commit names `one/.plan/maps/demo/tickets/03-commit.md`, uses the Git root as its working directory, and contains only that ticket. The unrelated staged file is not in the commit and remains staged or dirty. Existing claim trailers remain. |
+| Release from a subdirectory Space | Start with an orphaned claim, then call the ticket release route. | HTTP 200. The response keeps the existing release fields. The ticket has no claim and is open/frontier. The release commit contains only the same root-relative ticket path, names that path in the message, and keeps the session and `Chartr-Write` values. |
+| Claim root discovery failure | Make discovery return no repository or another Git failure during claim. | HTTP 500. Claim and init do not run. The ticket is not read or changed, no payload is written, no index path is staged, and no session starts. |
+| Release root discovery failure | Make discovery fail during release. | HTTP 500. No init or fallback occurs. The ticket is not changed, no success is reported, no dead tab is discarded, and no model rebuild occurs. |
+| Lifecycle path outside the root | Call the claim and release path-validation seam with the root itself, an outside path, and a path beginning with `..`. | The action rejects each path before ticket read or write, staging, or commit. The check uses a relative-path result, not a string prefix. |
+| Claim Git failure | Fail `git add` or `git commit` after the ticket write. | HTTP 500. No payload or session starts. The visible ticket or index change already made before the failure is not silently reset. Git output is included in the error. |
+| Release Git failure | Fail `git add` or `git commit` after the claim removal write. | HTTP 500. No success response, dead-tab discard, or rebuild occurs. Any visible ticket or index change left by the failed operation remains for the operator. |
+
+For successful claim and release, inspect the commit file list and message. Do
+not infer correctness only from the ticket model. The file-list check proves
+that an unrelated file in a shared Git root was not added to the lifecycle
+commit.
+
+### Smallest test seams
+
+- Use the existing process-boundary test rig and `POST /api/spaces` for
+  registration. Add fixture builders for a normal root, a subdirectory, a
+  linked worktree, a nested repository, a submodule, and a plain directory.
+- Use the model snapshot after registration or rebuild for Space path, name,
+  ID, map discovery, branch, and dirty state. This checks the public model and
+  does not test Git internals.
+- Use the existing claim/spawn and ticket-release HTTP routes for lifecycle
+  tests. Inspect the ticket file, the session or tab state, and the root Git
+  commit after each action.
+- Use one narrow Git runner seam, or a test Git shim, only for command absence,
+  controlled error classes, working directories, and exact arguments. It must
+  record calls and return configured output. It must not reimplement Git root
+  discovery.
+- Use one registry persistence seam for the post-init save failure. Assert the
+  accepted partial result instead of adding automatic cleanup.
+
+### Tests that remain unchanged
+
+Keep `TestRegisterInitialisesNonRepoAnnounced` unchanged. It is the regression
+for the existing non-repository behavior: a plain directory gets `.git`, the
+response says `gitInited: true`, the selected path and name remain visible, and
+an existing repository is not initialized again.
+
+Keep the existing root-based registration and lifecycle tests unchanged,
+including `TestForgetNotDestroy`, `TestRegistryLossIsRebuildable`,
+`TestReleaseTicketClearsAnOrphanedClaim`,
+`TestReleaseTicketDropsThePinnedDeadTab`,
+`TestReleaseTicketRefusedWhileSessionLive`, and
+`TestReleaseTicketRefusedWhenNotClaimed`. Add subdirectory cases beside these
+tests. Do not weaken their checks for registry persistence, unchanged
+repositories, claim state, release state, or commit count.
+
+### Rejected alternatives and trade-offs
+
+Testing only `Registry.Register` would miss HTTP status, response privacy,
+snapshot state, and registry side effects. Testing only real Git fixtures would
+not reliably prove missing Git, error classification, or exact command paths.
+Testing only helper functions would repeat Git behavior and could pass while
+the public route uses the wrong root. These are useful small checks, but none
+is a complete acceptance test.
+
+The chosen matrix costs fixture setup and one controlled command seam. That
+cost is accepted because it proves the operator-visible contract and the
+shared-root safety rule. It does not make Git's rules part of chartr's tests.
+
+Reopen this decision if a new repository form cannot use Git root discovery, if
+bare repositories become supported, if Git state must be limited to one Space,
+if a lifecycle action must commit more than one file, or if failed `git init`
+or lifecycle commits must be rolled back automatically.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,20 @@ _Avoid_: local settings, preferences, overrides
 The global settings route: the agent library and the paths of the files behind it, each openable in the operator's editor. Read-value-plus-open-file, never a second config store — there is nothing left to explain about layers.
 _Avoid_: settings screen, preferences, config panel, options
 
+### Git integration
+
+**Space path**:
+The directory selected when an operator registers a Space. It is the location for the Space's files and non-Git actions.
+_Avoid_: Git root when referring to the selected directory
+
+**Git root**:
+The root directory of the Git repository that contains the Space path. It is the location used for Git actions for that Space.
+_Avoid_: project root, repository path
+
+**Git action**:
+An operation that reads or changes Git repository state for a Space, such as repository setup, branch display, dirty status, or a claim or release commit.
+_Avoid_: file operation
+
 ### Ticket lifecycle
 
 **Implementing**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ A cockpit for driving wayfinder maps to completion: switch between project space
 ### The map
 
 **Space**:
-A git repository chartr drives, registered once and switched between. It owns exactly one working tree, which is what makes it the unit of serialisation.
+A selected directory that chartr registers and switches between. It has one Space path for its files and maps. Its Git actions use the Git root, and one Git root can serve more than one Space.
 _Avoid_: project, workspace, repo, folder
 
 **Map**:

--- a/internal/gitroot/root.go
+++ b/internal/gitroot/root.go
@@ -1,0 +1,82 @@
+// Package gitroot resolves the Git root for a Space path.
+package gitroot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrNotRepository means that the Space path is not inside a Git repository.
+// Registration may use this result to allow git init. Other errors must stop
+// registration.
+var ErrNotRepository = errors.New("git root: path is not inside a repository")
+
+// Resolve returns the nearest Git repository root for spacePath.
+func Resolve(spacePath string) (string, error) {
+	abs, err := filepath.Abs(spacePath)
+	if err != nil {
+		return "", fmt.Errorf("normalizing Space path %q: %w", spacePath, err)
+	}
+	spacePath = filepath.Clean(abs)
+
+	cmd := exec.Command("git", "-C", spacePath, "rev-parse", "--show-toplevel")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		output := strings.TrimSpace(string(out))
+		if isNoRepository(output) && !hasGitMarker(spacePath) {
+			return "", ErrNotRepository
+		}
+		if output == "" {
+			return "", fmt.Errorf("git root discovery in %s failed: %w", spacePath, err)
+		}
+		return "", fmt.Errorf("git root discovery in %s failed: %w\n%s", spacePath, err, output)
+	}
+
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		return "", fmt.Errorf("git root discovery in %s returned an empty root", spacePath)
+	}
+	abs, err = filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("normalizing Git root %q: %w", root, err)
+	}
+	return filepath.Clean(abs), nil
+}
+
+// Init creates a Git repository in spacePath.
+func Init(spacePath string) error {
+	cmd := exec.Command("git", "init")
+	cmd.Dir = spacePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		output := strings.TrimSpace(string(out))
+		if output == "" {
+			return fmt.Errorf("git init in %s failed: %w", spacePath, err)
+		}
+		return fmt.Errorf("git init in %s failed: %w\n%s", spacePath, err, output)
+	}
+	return nil
+}
+
+func isNoRepository(output string) bool {
+	return strings.Contains(output, "not a git repository (or any of the parent directories): .git")
+}
+
+// hasGitMarker only classifies a failed Git discovery. It never selects a
+// repository root; Git remains the source of truth for successful discovery.
+func hasGitMarker(spacePath string) bool {
+	current := filepath.Clean(spacePath)
+	for {
+		if _, err := os.Lstat(filepath.Join(current, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false
+		}
+		current = parent
+	}
+}

--- a/internal/gitroot/root.go
+++ b/internal/gitroot/root.go
@@ -47,6 +47,30 @@ func Resolve(spacePath string) (string, error) {
 	return filepath.Clean(abs), nil
 }
 
+// RelativePath returns path relative to root after resolving symlinks in both
+// paths. Git can report a canonical root even when the selected Space path uses
+// a symlink, so lexical filepath.Rel calls can otherwise produce a path outside
+// the repository.
+func RelativePath(root, path string) (string, error) {
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolving Git root %q: %w", root, err)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving path %q: %w", path, err)
+	}
+
+	rel, err := filepath.Rel(canonicalRoot, canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("locating path %q under Git root %q: %w", path, root, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside Git root %q", path, root)
+	}
+	return rel, nil
+}
+
 // Init creates a Git repository in spacePath.
 func Init(spacePath string) error {
 	cmd := exec.Command("git", "init")

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -130,8 +130,8 @@ type Space struct {
 	// Scratch marks the one synthetic home for ad-hoc shells. Registered spaces
 	// omit it; consumers that offer repository actions use it as their guard.
 	Scratch bool `json:"scratch,omitempty"`
-	// Path is the absolute working directory. For a registered space it is the
-	// working-tree root; for Scratch it is the operator's home directory.
+	// Path is the absolute Space path selected by the operator. For Scratch it is
+	// the operator's home directory.
 	Path string `json:"path"`
 	// Branch is the working tree's current git branch — the checked-out ref's
 	// short name, or a short sha for a detached HEAD — read live on each rebuild.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -17,14 +17,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/rengwu/chartr/internal/gitroot"
 )
 
 // ScratchID is the fixed identity of chartr's one synthetic Scratch space. A
@@ -263,31 +264,32 @@ func sortByOrder(entries []Entry) {
 	})
 }
 
-// Register makes path a space. It cleans the path to an absolute form, requires
-// it to be an existing directory, and — if it is not already a git repository —
-// runs `git init` there, reporting that it did so (never silent). A new space
-// appends: it takes max(order)+1, because the stored order belongs to the
-// operator and registering a repo is not a rearrangement. Registering an
-// already-registered path just refreshes its recency and leaves it where it sits.
-// The bool result is whether a `git init` was run.
-func (r *Registry) Register(path string) (Entry, bool, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return Entry{}, false, fmt.Errorf("registry: resolving %q: %w", path, err)
-	}
-	abs = filepath.Clean(abs)
+// ErrInvalidPath marks a registration path that is missing, inaccessible, or
+// not a directory. The server returns these errors as client errors. Git and
+// registry errors are not wrapped with this value, so the server returns them as
+// server errors.
+var ErrInvalidPath = errors.New("registry: invalid Space path")
 
-	info, err := os.Stat(abs)
+// Register makes path a Space. It cleans the path to an absolute form and
+// validates that it is an accessible directory before it runs any Git action.
+// If it is not already a Git repository, it runs `git init` there, reporting
+// that it did so (never silent). A new Space appends: it takes max(order)+1,
+// because the stored order belongs to the operator and registering a repository
+// is not a rearrangement. Registering an already-registered path just refreshes
+// its recency and leaves it where it sits. The bool result is whether a `git
+// init` was run.
+func (r *Registry) Register(path string) (Entry, bool, error) {
+	abs, err := validSpacePath(path)
 	if err != nil {
-		return Entry{}, false, fmt.Errorf("registry: %q is not a folder I can register: %w", path, err)
-	}
-	if !info.IsDir() {
-		return Entry{}, false, fmt.Errorf("registry: %q is a file, not a folder", path)
+		return Entry{}, false, err
 	}
 
 	gitInited := false
-	if !isGitRepo(abs) {
-		if err := gitInit(abs); err != nil {
+	if _, err := gitroot.Resolve(abs); err != nil {
+		if !errors.Is(err, gitroot.ErrNotRepository) {
+			return Entry{}, false, err
+		}
+		if err := gitroot.Init(abs); err != nil {
 			return Entry{}, false, err
 		}
 		gitInited = true
@@ -296,6 +298,10 @@ func (r *Registry) Register(path string) (Entry, bool, error) {
 	id := spaceID(abs)
 
 	r.mu.Lock()
+	before := make(map[string]Entry, len(r.entries))
+	for key, value := range r.entries {
+		before[key] = value
+	}
 	e, existed := r.entries[id]
 	if !existed {
 		e = Entry{ID: id, Path: abs, Order: r.nextOrderLocked()}
@@ -303,11 +309,51 @@ func (r *Registry) Register(path string) (Entry, bool, error) {
 	e.LastActive = time.Now().UTC()
 	r.entries[id] = e
 	err = r.saveLocked()
+	if err != nil {
+		// A failed persistence operation must not leave a registration that exists
+		// only in memory. Repository initialization is deliberately not rolled back,
+		// but the registry mutation is.
+		r.entries = before
+	}
 	r.mu.Unlock()
 	if err != nil {
 		return Entry{}, false, err
 	}
 	return e, gitInited, nil
+}
+
+// validSpacePath performs all path checks before Git sees the path. Reading one
+// directory entry distinguishes an accessible empty directory from a directory
+// whose permissions prevent Space discovery. It also keeps a missing path,
+// regular file, or inaccessible directory from reaching `git -C` or `git init`.
+func validSpacePath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("%w: resolving %q: %v", ErrInvalidPath, path, err)
+	}
+	abs = filepath.Clean(abs)
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q is not a folder I can register: %v", ErrInvalidPath, path, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%w: %q is a file, not a folder", ErrInvalidPath, path)
+	}
+
+	dir, err := os.Open(abs)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q is not accessible: %v", ErrInvalidPath, path, err)
+	}
+	_, readErr := dir.Readdirnames(1)
+	closeErr := dir.Close()
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return "", fmt.Errorf("%w: %q is not accessible: %v", ErrInvalidPath, path, readErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("%w: closing %q after access check: %v", ErrInvalidPath, path, closeErr)
+	}
+	return abs, nil
 }
 
 // Deregister forgets a space: it removes the registry entry and its local order
@@ -523,20 +569,4 @@ func (r *Registry) densifyLocked() {
 func spaceID(absPath string) string {
 	sum := sha256.Sum256([]byte(absPath))
 	return hex.EncodeToString(sum[:])[:12]
-}
-
-func isGitRepo(dir string) bool {
-	// A .git entry (directory for a normal clone, a file for a linked worktree)
-	// marks the repository root; chartr registers repository roots.
-	_, err := os.Stat(filepath.Join(dir, ".git"))
-	return err == nil
-}
-
-func gitInit(dir string) error {
-	cmd := exec.Command("git", "init")
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("registry: git init in %s failed: %w\n%s", dir, err, out)
-	}
-	return nil
 }

--- a/internal/server/claim.go
+++ b/internal/server/claim.go
@@ -48,10 +48,10 @@ type claim struct {
 // It never rewrites history and never pushes (ADR 0008): the claim is a new
 // commit, full stop. The returned error surfaces to the operator — a repo with no
 // git identity, say — with nothing launched.
-func writeClaimCommit(repo, ticketPath, sessionID string, at string, c claim) error {
-	rel, err := filepath.Rel(repo, ticketPath)
+func writeClaimCommit(gitRoot, ticketPath, sessionID string, at string, c claim) error {
+	rel, err := filepath.Rel(gitRoot, ticketPath)
 	if err != nil {
-		return fmt.Errorf("locating ticket under the space: %w", err)
+		return fmt.Errorf("locating ticket under the Git root: %w", err)
 	}
 
 	src, err := os.ReadFile(ticketPath)
@@ -66,10 +66,10 @@ func writeClaimCommit(repo, ticketPath, sessionID string, at string, c claim) er
 	// Stage then partial-commit the one path. `git add` makes an untracked ticket
 	// known to git; `--only -- <path>` commits from HEAD plus that path alone,
 	// leaving the rest of the index untouched.
-	if out, err := git(repo, "add", "--", rel); err != nil {
+	if out, err := git(gitRoot, "add", "--", rel); err != nil {
 		return fmt.Errorf("staging the claim: %w\n%s", err, out)
 	}
-	if out, err := git(repo, "commit", "--only", "-m", claimMessage(rel, c), "--", rel); err != nil {
+	if out, err := git(gitRoot, "commit", "--only", "-m", claimMessage(rel, c), "--", rel); err != nil {
 		return fmt.Errorf("committing the claim: %w\n%s", err, out)
 	}
 	return nil
@@ -150,10 +150,10 @@ func stripClaim(src string) string {
 // discipline the claim uses (ADR 0008). Recording the release as its own commit
 // keeps git the whole audit trail: the ticket's history reads claim → release, and
 // the stale claim is cleared by an operator act, never on its own.
-func writeReleaseCommit(repo, ticketPath, sessionID string) error {
-	rel, err := filepath.Rel(repo, ticketPath)
+func writeReleaseCommit(gitRoot, ticketPath, sessionID string) error {
+	rel, err := filepath.Rel(gitRoot, ticketPath)
 	if err != nil {
-		return fmt.Errorf("locating ticket under the space: %w", err)
+		return fmt.Errorf("locating ticket under the Git root: %w", err)
 	}
 	src, err := os.ReadFile(ticketPath)
 	if err != nil {
@@ -162,11 +162,11 @@ func writeReleaseCommit(repo, ticketPath, sessionID string) error {
 	if err := os.WriteFile(ticketPath, []byte(stripClaim(string(src))), 0o644); err != nil {
 		return fmt.Errorf("clearing the claim on the ticket: %w", err)
 	}
-	if out, err := git(repo, "add", "--", rel); err != nil {
+	if out, err := git(gitRoot, "add", "--", rel); err != nil {
 		return fmt.Errorf("staging the release: %w\n%s", err, out)
 	}
 	msg := fmt.Sprintf("Release %s back to the frontier\n\nSession: %s\nChartr-Write: true", rel, sessionID)
-	if out, err := git(repo, "commit", "--only", "-m", msg, "--", rel); err != nil {
+	if out, err := git(gitRoot, "commit", "--only", "-m", msg, "--", rel); err != nil {
 		return fmt.Errorf("committing the release: %w\n%s", err, out)
 	}
 	return nil

--- a/internal/server/claim.go
+++ b/internal/server/claim.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rengwu/chartr/internal/gitroot"
 	"github.com/rengwu/chartr/internal/prompt"
 )
 
@@ -49,7 +50,7 @@ type claim struct {
 // commit, full stop. The returned error surfaces to the operator — a repo with no
 // git identity, say — with nothing launched.
 func writeClaimCommit(gitRoot, ticketPath, sessionID string, at string, c claim) error {
-	rel, err := filepath.Rel(gitRoot, ticketPath)
+	rel, err := gitroot.RelativePath(gitRoot, ticketPath)
 	if err != nil {
 		return fmt.Errorf("locating ticket under the Git root: %w", err)
 	}
@@ -151,7 +152,7 @@ func stripClaim(src string) string {
 // keeps git the whole audit trail: the ticket's history reads claim → release, and
 // the stale claim is cleared by an operator act, never on its own.
 func writeReleaseCommit(gitRoot, ticketPath, sessionID string) error {
-	rel, err := filepath.Rel(gitRoot, ticketPath)
+	rel, err := gitroot.RelativePath(gitRoot, ticketPath)
 	if err != nil {
 		return fmt.Errorf("locating ticket under the Git root: %w", err)
 	}

--- a/internal/server/gitbranch.go
+++ b/internal/server/gitbranch.go
@@ -4,16 +4,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rengwu/chartr/internal/gitroot"
 )
 
-// gitBranch reports the working tree's current branch by reading .git/HEAD — the
-// checked-out ref's short name, or a short sha for a detached HEAD. It follows
-// the one level of indirection a linked worktree uses (.git as a file pointing
-// at the real gitdir). Empty on anything it can't read, so the sidebar simply
-// omits the branch rather than surfacing an error: this is a label, not a
-// guarantee, and reading a file (not shelling out to git) keeps it cheap enough
-// to run on every rebuild.
-func gitBranch(root string) string {
+// gitBranch resolves the Git root from the Space path, then reports the
+// working tree's current branch by reading .git/HEAD — the checked-out ref's
+// short name, or a short sha for a detached HEAD. It follows the one level of
+// indirection a linked worktree uses (.git as a file pointing at the real
+// gitdir). Empty on anything it cannot read, so the sidebar omits the branch
+// rather than surfacing an error.
+func gitBranch(spacePath string) string {
+	root, err := gitroot.Resolve(spacePath)
+	if err != nil {
+		return ""
+	}
 	dir := filepath.Join(root, ".git")
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -29,6 +34,9 @@ func gitBranch(root string) string {
 		p := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(b)), "gitdir:"))
 		if p == "" {
 			return ""
+		}
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(root, p)
 		}
 		dir = p
 	}

--- a/internal/server/gitstatus.go
+++ b/internal/server/gitstatus.go
@@ -1,8 +1,11 @@
 package server
 
-// gitDirty reports whether the working tree at root carries uncommitted changes —
-// anything `git status --porcelain` lists: modified, staged, or untracked files
-// (gitignored paths, like chartr's own `run/` payloads, never count). It is
+import "github.com/rengwu/chartr/internal/gitroot"
+
+// gitDirty resolves the Git root from the Space path, then reports whether that
+// working tree carries uncommitted changes — anything `git status --porcelain`
+// lists: modified, staged, or untracked files (gitignored paths, like chartr's
+// own `run/` payloads, never count). It is
 // the dirty badge (spec, Git and the gate; story 68): surfaced so the operator can
 // judge whether a session's or a shell's debris is harmless, and never a spawn
 // gate. A label, not a guarantee — a repo it cannot read reads clean rather than
@@ -14,7 +17,11 @@ package server
 // on. Without the flag the badge's read would race the gate's own `git add` for
 // the lock and fail the commit. Nothing chartr reads for a badge is worth an
 // index lock.
-func gitDirty(root string) bool {
+func gitDirty(spacePath string) bool {
+	root, err := gitroot.Resolve(spacePath)
+	if err != nil {
+		return false
+	}
 	out, err := git(root, "--no-optional-locks", "status", "--porcelain")
 	if err != nil {
 		return false

--- a/internal/server/halt.go
+++ b/internal/server/halt.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/rengwu/chartr/internal/adapter"
+	"github.com/rengwu/chartr/internal/gitroot"
 	"github.com/rengwu/chartr/internal/mapscan"
 	"github.com/rengwu/chartr/internal/model"
 	"github.com/rengwu/chartr/internal/registry"
@@ -221,7 +222,12 @@ func (s *Server) handleRelease(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusNotFound, err.Error())
 		return
 	}
-	if err := writeReleaseCommit(e.Path, ticketPath, info.ID); err != nil {
+	gitRoot, err := gitroot.Resolve(e.Path)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "locating Git root for the release: "+err.Error())
+		return
+	}
+	if err := writeReleaseCommit(gitRoot, ticketPath, info.ID); err != nil {
 		httpError(w, http.StatusInternalServerError, "releasing the claim: "+err.Error())
 		return
 	}

--- a/internal/server/halt_test.go
+++ b/internal/server/halt_test.go
@@ -194,6 +194,49 @@ func TestHaltReleaseReturnsTicketToFrontier(t *testing.T) {
 	}
 }
 
+// The session-keyed release uses the Git root for a child Space too. Its commit
+// must name only the nested ticket, even when the root has another change.
+func TestHaltReleaseFromSubdirectoryCommitsOnlyTheNestedTicket(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+	space := filepath.Join(repo, "child")
+
+	chartrtest.WriteMap(t, space, "widget", mapBody)
+	chartrtest.WriteTicket(t, space, "widget", "01-first.md", ticket(1, "First", "[]", "task", ""))
+	chartrtest.WriteFile(t, repo, "outside.txt", "unrelated root change")
+	chartrtest.StubDyingAgent(t, "claude")
+
+	resp := register(t, h, space)
+	sid := spawnThenDie(t, h, resp.ID, "widget", 1, "implement")
+
+	if code, body := h.Release(resp.ID, sid); code != 200 {
+		t.Fatalf("release = %d, body %s", code, body)
+	}
+
+	rel := filepath.Join("child", ".plan", "widget", "tickets", "01-first.md")
+	files := chartrtest.Git(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if got := nonEmptyLines(files); len(got) != 1 || got[0] != rel {
+		t.Errorf("release commit touched %v, want exactly [%s]", got, rel)
+	}
+	if strings.Contains(files, "outside.txt") {
+		t.Errorf("release commit included unrelated root change:\n%s", files)
+	}
+	staged := chartrtest.Git(t, repo, "diff", "--cached", "--name-only")
+	if strings.Contains(staged, "outside.txt") {
+		t.Errorf("release staged unrelated root change:\n%s", staged)
+	}
+	if n := commitCount(t, repo); n != "2" {
+		t.Errorf("commits after nested session release = %s, want 2 (claim + release)", n)
+	}
+	body, err := os.ReadFile(filepath.Join(space, ".plan", "widget", "tickets", "01-first.md"))
+	if err != nil {
+		t.Fatalf("reading nested ticket after release: %v", err)
+	}
+	if strings.Contains(string(body), "claimed_by") {
+		t.Errorf("release left claimed_by on the nested ticket:\n%s", body)
+	}
+}
+
 // Respawn: a fresh session on the same ticket. A new claim supersedes the stale
 // one (re-stamped in place, its own commit), so the ticket stays claimed but by the
 // new session, and nothing is doubled.

--- a/internal/server/release.go
+++ b/internal/server/release.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/rengwu/chartr/internal/gitroot"
 	"github.com/rengwu/chartr/internal/mapscan"
 	"github.com/rengwu/chartr/internal/terminal"
 )
@@ -78,10 +79,15 @@ func (s *Server) handleReleaseTicket(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusNotFound, err.Error())
 		return
 	}
+	gitRoot, err := gitroot.Resolve(e.Path)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "locating Git root for the release: "+err.Error())
+		return
+	}
 	// The commit names the session being released, read off the ticket's own
 	// frontmatter — the claim is the only thing that knows, since by construction
 	// there may be no tab left to ask.
-	if err := writeReleaseCommit(e.Path, ticketPath, tk.ClaimedBy); err != nil {
+	if err := writeReleaseCommit(gitRoot, ticketPath, tk.ClaimedBy); err != nil {
 		httpError(w, http.StatusInternalServerError, "releasing the claim: "+err.Error())
 		return
 	}

--- a/internal/server/release_test.go
+++ b/internal/server/release_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -98,6 +99,52 @@ func TestReleaseTicketClearsAnOrphanedClaim(t *testing.T) {
 	// frontmatter — by construction there is no tab left to ask.
 	if msg := chartrtest.Git(t, repo, "log", "-1", "--format=%B"); !strings.Contains(msg, "sess-gone") {
 		t.Errorf("release commit does not name the released session:\n%s", msg)
+	}
+}
+
+// A ticket release from a child Space uses the ticket path relative to the Git
+// root. The unrelated root change stays out of the release commit and index.
+func TestReleaseTicketFromSubdirectoryCommitsOnlyTheNestedTicket(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+	space := filepath.Join(repo, "child")
+
+	chartrtest.WriteMap(t, space, "widget", mapBody)
+	chartrtest.WriteTicket(t, space, "widget", "01-first.md",
+		claimedTicket(1, "First", "sess-gone", "2026-07-20T09:00:00Z"))
+	commitAll(t, repo)
+	chartrtest.WriteFile(t, repo, "outside.txt", "unrelated root change")
+
+	resp := register(t, h, space)
+	if code, body := h.ReleaseTicket(resp.ID, "widget", 1); code != 200 {
+		t.Fatalf("release = %d, body %s", code, body)
+	}
+
+	rel := filepath.Join("child", ".plan", "widget", "tickets", "01-first.md")
+	files := chartrtest.Git(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if got := nonEmptyLines(files); len(got) != 1 || got[0] != rel {
+		t.Errorf("release commit touched %v, want exactly [%s]", got, rel)
+	}
+	if strings.Contains(files, "outside.txt") {
+		t.Errorf("release commit included unrelated root change:\n%s", files)
+	}
+	staged := chartrtest.Git(t, repo, "diff", "--cached", "--name-only")
+	if strings.Contains(staged, "outside.txt") {
+		t.Errorf("release staged unrelated root change:\n%s", staged)
+	}
+	if n := commitCount(t, repo); n != "2" {
+		t.Errorf("commits after nested release = %s, want 2 (fixture + release)", n)
+	}
+	body, err := os.ReadFile(filepath.Join(space, ".plan", "widget", "tickets", "01-first.md"))
+	if err != nil {
+		t.Fatalf("reading nested ticket after release: %v", err)
+	}
+	if strings.Contains(string(body), "claimed_by") {
+		t.Errorf("release left claimed_by on the nested ticket:\n%s", body)
+	}
+	msg := chartrtest.Git(t, repo, "log", "-1", "--format=%B")
+	if !strings.Contains(msg, "Release "+rel) || !strings.Contains(msg, "sess-gone") {
+		t.Errorf("release commit does not use the root-relative ticket path or session:\n%s", msg)
 	}
 }
 

--- a/internal/server/spaces.go
+++ b/internal/server/spaces.go
@@ -80,8 +80,13 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	entry, gitInited, err := s.reg.Register(body.Path)
 	if err != nil {
-		// A bad path is the operator's to fix; surface it as the response.
-		httpError(w, http.StatusBadRequest, err.Error())
+		status := http.StatusInternalServerError
+		if errors.Is(err, registry.ErrInvalidPath) {
+			status = http.StatusBadRequest
+		}
+		// Invalid paths are the operator's to fix. Git and registry failures are
+		// server errors because chartr could not complete the action safely.
+		httpError(w, status, err.Error())
 		return
 	}
 	s.rebuild()

--- a/internal/server/spaces_test.go
+++ b/internal/server/spaces_test.go
@@ -3,8 +3,10 @@ package server_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -42,6 +44,9 @@ func register(t *testing.T, h *chartrtest.Chartr, path string) registerResp {
 	var r registerResp
 	if err := json.Unmarshal([]byte(body), &r); err != nil {
 		t.Fatalf("register response not JSON: %v (%q)", err, body)
+	}
+	if strings.Contains(body, "gitRoot") || strings.Contains(body, "git_root") {
+		t.Fatalf("register response exposes the internal Git root: %s", body)
 	}
 	return r
 }
@@ -91,6 +96,305 @@ func TestRegisterInitialisesNonRepoAnnounced(t *testing.T) {
 	if resp2.GitInited {
 		t.Error("gitInited = true for an existing repo, want false")
 	}
+}
+
+func TestRegisterSubdirectoryUsesRootGitStateAndSpaceFiles(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+	firstPath := filepath.Join(repo, "first")
+	secondPath := filepath.Join(repo, "second")
+
+	chartrtest.WriteMap(t, firstPath, "first-map", mapBody)
+	chartrtest.WriteTicket(t, firstPath, "first-map", "01-first.md", ticket(1, "First", "[]", "task", ""))
+	writeWorkspaceSkill(t, firstPath, "implement", "", "First skill")
+	chartrtest.WriteMap(t, secondPath, "second-map", mapBody)
+	chartrtest.WriteTicket(t, secondPath, "second-map", "01-second.md", ticket(1, "Second", "[]", "task", ""))
+	writeWorkspaceSkill(t, secondPath, "research", "", "Second skill")
+	chartrtest.Git(t, repo, "add", "--all")
+	chartrtest.Git(t, repo, "commit", "-qm", "baseline")
+
+	// This change is outside both selected Space paths. A root-wide Git action
+	// must report it for both Spaces.
+	chartrtest.WriteFile(t, repo, "outside.txt", "changed outside both Spaces")
+
+	first := register(t, h, firstPath)
+	second := register(t, h, secondPath)
+
+	if first.GitInited || second.GitInited {
+		t.Fatalf("child registration reported git init: first=%v second=%v", first.GitInited, second.GitInited)
+	}
+	if first.Path != firstPath || second.Path != secondPath {
+		t.Fatalf("registration paths = %q and %q, want %q and %q", first.Path, second.Path, firstPath, secondPath)
+	}
+	if first.ID == second.ID {
+		t.Fatalf("two Space paths share identity %q", first.ID)
+	}
+	for _, path := range []string{firstPath, secondPath} {
+		if _, err := os.Stat(filepath.Join(path, ".git")); !os.IsNotExist(err) {
+			t.Errorf("registration created %s/.git: %v", path, err)
+		}
+	}
+
+	snapshot := h.Snapshot(ctx(t))
+	firstSpace := findSpace(t, snapshot, first.ID)
+	secondSpace := findSpace(t, snapshot, second.ID)
+	paths := map[string]string{"first": firstPath, "second": secondPath}
+	spaces := map[string]model.Space{"first": firstSpace, "second": secondSpace}
+	for name, space := range spaces {
+		if space.Path != paths[name] {
+			t.Errorf("%s Space path = %q, want %q", name, space.Path, paths[name])
+		}
+		if space.Branch != "main" {
+			t.Errorf("%s branch = %q, want main from the Git root", name, space.Branch)
+		}
+		if !space.Dirty {
+			t.Errorf("%s is clean, want the change outside the selected Space path", name)
+		}
+	}
+	if len(firstSpace.Maps) != 1 || firstSpace.Maps[0].Slug != "first-map" {
+		t.Errorf("first Space maps = %+v, want only first-map", firstSpace.Maps)
+	}
+	if len(secondSpace.Maps) != 1 || secondSpace.Maps[0].Slug != "second-map" {
+		t.Errorf("second Space maps = %+v, want only second-map", secondSpace.Maps)
+	}
+	if !hasWorkspaceSkill(firstSpace, "implement") || hasWorkspaceSkill(firstSpace, "research") {
+		t.Errorf("first Space skills are not scoped: %+v", firstSpace.Skills)
+	}
+	if !hasWorkspaceSkill(secondSpace, "research") || hasWorkspaceSkill(secondSpace, "implement") {
+		t.Errorf("second Space skills are not scoped: %+v", secondSpace.Skills)
+	}
+}
+
+func hasWorkspaceSkill(space model.Space, name string) bool {
+	for _, skill := range space.Skills {
+		if skill.Name == name && skill.Layer == "workspace" {
+			return true
+		}
+	}
+	return false
+}
+
+func registerFailure(t *testing.T, h *chartrtest.Chartr, path string, wantStatus int) {
+	t.Helper()
+	code, body := h.Post("/api/spaces", map[string]string{"path": path})
+	if code != wantStatus {
+		t.Fatalf("register %s = %d, want %d, body %s", path, code, wantStatus, body)
+	}
+	var response map[string]any
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatalf("registration error is not JSON: %v (%q)", err, body)
+	}
+	if message, ok := response["error"].(string); !ok || strings.TrimSpace(message) == "" {
+		t.Fatalf("registration error has no message: %s", body)
+	}
+	for _, field := range []string{"id", "path", "gitInited"} {
+		if _, ok := response[field]; ok {
+			t.Errorf("registration error exposes success field %q: %s", field, body)
+		}
+	}
+}
+
+func assertNotRegistered(t *testing.T, h *chartrtest.Chartr, path string) {
+	t.Helper()
+	if registeredPath(t, h, path) {
+		t.Errorf("failed registration added %s to the registry", path)
+	}
+}
+
+func assertNoGitEntry(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(path, ".git")); !os.IsNotExist(err) {
+		t.Errorf("failed registration created %s/.git: %v", path, err)
+	}
+}
+
+func TestRegisterLinkedWorktreeUsesLinkedRoot(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+	chartrtest.Git(t, repo, "commit", "--allow-empty", "-qm", "baseline")
+	linked := filepath.Join(t.TempDir(), "linked")
+	chartrtest.Git(t, repo, "worktree", "add", "-q", "-b", "linked-main", linked)
+	child := filepath.Join(linked, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("creating linked worktree child: %v", err)
+	}
+	chartrtest.WriteFile(t, linked, "outside-child.txt", "dirty in the linked worktree\n")
+
+	dotGit := filepath.Join(linked, ".git")
+	dotGitBefore, err := os.ReadFile(dotGit)
+	if err != nil {
+		t.Fatalf("reading linked worktree .git file: %v", err)
+	}
+	if info, err := os.Stat(dotGit); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("linked worktree .git is not a file: %v", err)
+	}
+
+	root := register(t, h, linked)
+	spaceChild := register(t, h, child)
+	if root.GitInited || spaceChild.GitInited {
+		t.Fatalf("linked worktree registration ran git init: root=%v child=%v", root.GitInited, spaceChild.GitInited)
+	}
+	if root.Path != linked || spaceChild.Path != child {
+		t.Fatalf("registration paths = %q and %q, want %q and %q", root.Path, spaceChild.Path, linked, child)
+	}
+	assertNoGitEntry(t, child)
+	if dotGitAfter, err := os.ReadFile(dotGit); err != nil || string(dotGitAfter) != string(dotGitBefore) {
+		t.Errorf("linked worktree .git file changed: before=%q after=%q err=%v", dotGitBefore, dotGitAfter, err)
+	}
+
+	snapshot := h.Snapshot(ctx(t))
+	for _, space := range []model.Space{
+		findSpace(t, snapshot, root.ID),
+		findSpace(t, snapshot, spaceChild.ID),
+	} {
+		if space.Branch != "linked-main" {
+			t.Errorf("linked worktree branch = %q, want linked-main", space.Branch)
+		}
+		if !space.Dirty {
+			t.Errorf("linked worktree Space is clean, want the dirty change in its Git root")
+		}
+	}
+}
+
+func TestRegisterNestedRepositoryAndSubmoduleUseInnermostRoots(t *testing.T) {
+	h := chartrtest.Start(t)
+	outer := chartrtest.NewSpaceRepo(t)
+	chartrtest.WriteFile(t, outer, "outer.txt", "outer\n")
+	chartrtest.Git(t, outer, "add", "--all")
+	chartrtest.Git(t, outer, "commit", "-qm", "outer baseline")
+	outerHead := chartrtest.Git(t, outer, "rev-parse", "HEAD")
+
+	nested := filepath.Join(outer, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("creating nested repository: %v", err)
+	}
+	chartrtest.Git(t, nested, "init", "-q", "-b", "nested-main")
+	chartrtest.Git(t, nested, "config", "user.email", "chartr-test@example.com")
+	chartrtest.Git(t, nested, "config", "user.name", "Chartr Test")
+	chartrtest.Git(t, nested, "commit", "--allow-empty", "-qm", "nested baseline")
+	nestedGitHeadBefore := readFile(t, filepath.Join(nested, ".git", "HEAD"))
+	chartrtest.WriteFile(t, nested, "nested-dirty.txt", "nested change\n")
+
+	source := chartrtest.NewSpaceRepo(t)
+	chartrtest.WriteFile(t, source, "source.txt", "source\n")
+	chartrtest.Git(t, source, "add", "--all")
+	chartrtest.Git(t, source, "commit", "-qm", "source baseline")
+	submodule := filepath.Join(outer, "submodule")
+	chartrtest.Git(t, outer, "-c", "protocol.file.allow=always", "submodule", "add", "-q", source, "submodule")
+	chartrtest.Git(t, submodule, "checkout", "-q", "-b", "submodule-main")
+	submoduleGitBefore := readFile(t, filepath.Join(submodule, ".git"))
+	chartrtest.WriteFile(t, submodule, "submodule-dirty.txt", "submodule change\n")
+
+	nestedResp := register(t, h, nested)
+	submoduleResp := register(t, h, submodule)
+	if nestedResp.GitInited || submoduleResp.GitInited {
+		t.Fatalf("nested repository registration ran git init: nested=%v submodule=%v", nestedResp.GitInited, submoduleResp.GitInited)
+	}
+	if nestedResp.Path != nested || submoduleResp.Path != submodule {
+		t.Fatalf("registration paths = %q and %q, want %q and %q", nestedResp.Path, submoduleResp.Path, nested, submodule)
+	}
+	if got := chartrtest.Git(t, outer, "rev-parse", "HEAD"); got != outerHead {
+		t.Errorf("outer repository HEAD changed from %s to %s", outerHead, got)
+	}
+	if got := readFile(t, filepath.Join(nested, ".git", "HEAD")); got != nestedGitHeadBefore {
+		t.Errorf("nested repository .git/HEAD changed from %q to %q", nestedGitHeadBefore, got)
+	}
+	if got := readFile(t, filepath.Join(submodule, ".git")); got != submoduleGitBefore {
+		t.Errorf("submodule .git file changed from %q to %q", submoduleGitBefore, got)
+	}
+
+	snapshot := h.Snapshot(ctx(t))
+	nestedSpace := findSpace(t, snapshot, nestedResp.ID)
+	submoduleSpace := findSpace(t, snapshot, submoduleResp.ID)
+	if nestedSpace.Branch != "nested-main" || !nestedSpace.Dirty {
+		t.Errorf("nested Space Git state = branch %q, dirty %v; want nested-main and dirty", nestedSpace.Branch, nestedSpace.Dirty)
+	}
+	if submoduleSpace.Branch != "submodule-main" || !submoduleSpace.Dirty {
+		t.Errorf("submodule Space Git state = branch %q, dirty %v; want submodule-main and dirty", submoduleSpace.Branch, submoduleSpace.Dirty)
+	}
+}
+
+func TestRegisterFailuresDoNotInitOrPersist(t *testing.T) {
+	h := chartrtest.Start(t)
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	registerFailure(t, h, missing, http.StatusBadRequest)
+	assertNotRegistered(t, h, missing)
+
+	regularFile := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(regularFile, []byte("not a Space\n"), 0o644); err != nil {
+		t.Fatalf("creating regular file: %v", err)
+	}
+	registerFailure(t, h, regularFile, http.StatusBadRequest)
+	assertNotRegistered(t, h, regularFile)
+
+	if runtime.GOOS != "windows" {
+		inaccessible := filepath.Join(t.TempDir(), "inaccessible")
+		if err := os.Mkdir(inaccessible, 0o755); err != nil {
+			t.Fatalf("creating inaccessible directory: %v", err)
+		}
+		if err := os.Chmod(inaccessible, 0); err != nil {
+			t.Fatalf("removing directory permissions: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(inaccessible, 0o755) })
+		probe, err := os.Open(inaccessible)
+		if err == nil {
+			_ = probe.Close()
+			t.Log("skipping inaccessible-directory case because this process can open mode-000 directories")
+		} else {
+			registerFailure(t, h, inaccessible, http.StatusBadRequest)
+			assertNotRegistered(t, h, inaccessible)
+			if err := os.Chmod(inaccessible, 0o755); err != nil {
+				t.Fatalf("restoring inaccessible directory permissions: %v", err)
+			}
+			assertNoGitEntry(t, inaccessible)
+		}
+	}
+
+	broken := t.TempDir()
+	brokenGit := filepath.Join(broken, ".git")
+	brokenGitBefore := []byte("gitdir: /path/that/does/not/exist\n")
+	if err := os.WriteFile(brokenGit, brokenGitBefore, 0o644); err != nil {
+		t.Fatalf("creating broken Git metadata: %v", err)
+	}
+	registerFailure(t, h, broken, http.StatusInternalServerError)
+	assertNotRegistered(t, h, broken)
+	if got, err := os.ReadFile(brokenGit); err != nil || string(got) != string(brokenGitBefore) {
+		t.Errorf("broken .git marker changed: before=%q after=%q err=%v", brokenGitBefore, got, err)
+	}
+
+	bare := t.TempDir()
+	chartrtest.Git(t, bare, "init", "-q", "--bare")
+	registerFailure(t, h, bare, http.StatusInternalServerError)
+	assertNotRegistered(t, h, bare)
+	assertNoGitEntry(t, bare)
+
+	missingGit := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	registerFailure(t, h, missingGit, http.StatusInternalServerError)
+	assertNotRegistered(t, h, missingGit)
+	assertNoGitEntry(t, missingGit)
+}
+
+func TestRegisterRegistryFailureIsServerErrorAndKeepsInit(t *testing.T) {
+	h := chartrtest.Start(t)
+	plain := t.TempDir()
+
+	if err := os.Chmod(h.ConfigDir, 0o500); err != nil {
+		t.Fatalf("making config directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(h.ConfigDir, 0o700) })
+	probe := filepath.Join(h.ConfigDir, "write-probe")
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err == nil {
+		_ = os.Remove(probe)
+		t.Skip("process can write a mode-0500 config directory")
+	}
+
+	registerFailure(t, h, plain, http.StatusInternalServerError)
+	if _, err := os.Stat(filepath.Join(plain, ".git")); err != nil {
+		t.Errorf("registry failure removed the successful git init: %v", err)
+	}
+	assertNotRegistered(t, h, plain)
 }
 
 // De-registering forgets the entry and touches nothing in the repository — not

--- a/internal/server/spawn.go
+++ b/internal/server/spawn.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rengwu/chartr/internal/adapter"
 	"github.com/rengwu/chartr/internal/config"
+	"github.com/rengwu/chartr/internal/gitroot"
 	"github.com/rengwu/chartr/internal/mapscan"
 	"github.com/rengwu/chartr/internal/model"
 	"github.com/rengwu/chartr/internal/prompt"
@@ -291,12 +292,16 @@ func (s *Server) launchSession(in sessionLaunch) (map[string]any, int, error) {
 	if err != nil {
 		return nil, http.StatusNotFound, err
 	}
+	gitRoot, err := gitroot.Resolve(in.entry.Path)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("locating Git root for the claim: %w", err)
+	}
 
 	// The claim commit — chartr's one write here (ADR 0008), pathspec-limited
 	// to the ticket file and carrying the agent and payload-hash trailers. On a
 	// respawn the ticket already carries a stale claim; stampClaim replaces it, so
 	// the new session id supersedes the dead one.
-	if err := writeClaimCommit(in.entry.Path, ticketPath, in.sessionID, claimedAt, claim{
+	if err := writeClaimCommit(gitRoot, ticketPath, in.sessionID, claimedAt, claim{
 		SessionID:  in.sessionID,
 		Role:       in.role,
 		Agent:      in.spec.Name,

--- a/internal/server/spawn_test.go
+++ b/internal/server/spawn_test.go
@@ -234,6 +234,42 @@ func TestSpawnFromSubdirectoryCommitsOnlyTheNestedTicket(t *testing.T) {
 	}
 }
 
+// Git can return a canonical path while the registry keeps the selected path
+// through a symlink. Claim commits must use one path form for both values.
+func TestSpawnFromSymlinkedSpacePathCommitsOnlyTheNestedTicket(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+
+	aliasParent := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(filepath.Dir(repo), aliasParent); err != nil {
+		t.Skipf("creating a symlink for the temporary repository: %v", err)
+	}
+	aliasedRepo := filepath.Join(aliasParent, filepath.Base(repo))
+	space := filepath.Join(aliasedRepo, "child")
+
+	chartrtest.WriteMap(t, space, "widget", mapBody)
+	chartrtest.WriteTicket(t, space, "widget", "01-first.md", ticket(1, "First", "[]", "task", ""))
+	chartrtest.Git(t, repo, "add", "--all")
+	chartrtest.Git(t, repo, "commit", "-qm", "baseline")
+	chartrtest.WriteFile(t, repo, "outside.txt", "unrelated root change")
+	chartrtest.StubAgent(t, "claude")
+
+	resp := register(t, h, space)
+	sp := mustSpawn(t, h, resp.ID, "widget", 1, "implement")
+
+	rel := filepath.Join("child", ".plan", "widget", "tickets", "01-first.md")
+	files := chartrtest.Git(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if got := nonEmptyLines(files); len(got) != 1 || got[0] != rel {
+		t.Errorf("claim commit touched %v, want exactly [%s]", got, rel)
+	}
+	if strings.Contains(files, "outside.txt") {
+		t.Errorf("claim commit included unrelated root change:\n%s", files)
+	}
+	if msg := chartrtest.Git(t, repo, "log", "-1", "--format=%B"); !strings.Contains(msg, "Claim "+rel) || !strings.Contains(msg, "Session: "+sp.SessionID) {
+		t.Errorf("claim commit does not use the canonical root-relative path or session:\n%s", msg)
+	}
+}
+
 // A spawn that names no agent is refused (ticket 04) — there is no binding to fall
 // back to any more — and the refusal blocks nothing else: no claim is written, the
 // ticket stays open with no session tab, and the space is still fully usable as a

--- a/internal/server/spawn_test.go
+++ b/internal/server/spawn_test.go
@@ -190,6 +190,50 @@ func TestSpawnWiresTheWholeChain(t *testing.T) {
 	}
 }
 
+// A Space below the Git root keeps its Space files below that path, but its
+// claim commit uses the root-relative ticket path. An unrelated root change
+// stays out of both the index and the commit.
+func TestSpawnFromSubdirectoryCommitsOnlyTheNestedTicket(t *testing.T) {
+	h := chartrtest.Start(t)
+	repo := chartrtest.NewSpaceRepo(t)
+	space := filepath.Join(repo, "child")
+
+	chartrtest.WriteMap(t, space, "widget", mapBody)
+	chartrtest.WriteTicket(t, space, "widget", "01-first.md", ticket(1, "First", "[]", "task", ""))
+	chartrtest.Git(t, repo, "add", "--all")
+	chartrtest.Git(t, repo, "commit", "-qm", "baseline")
+	chartrtest.WriteFile(t, repo, "outside.txt", "unrelated root change")
+	chartrtest.StubAgent(t, "claude")
+
+	resp := register(t, h, space)
+	sp := mustSpawn(t, h, resp.ID, "widget", 1, "implement")
+
+	rel := filepath.Join("child", ".plan", "widget", "tickets", "01-first.md")
+	files := chartrtest.Git(t, repo, "show", "--name-only", "--format=", "HEAD")
+	if got := nonEmptyLines(files); len(got) != 1 || got[0] != rel {
+		t.Errorf("claim commit touched %v, want exactly [%s]", got, rel)
+	}
+	if strings.Contains(files, "outside.txt") {
+		t.Errorf("claim commit included unrelated root change:\n%s", files)
+	}
+	staged := chartrtest.Git(t, repo, "diff", "--cached", "--name-only")
+	if strings.Contains(staged, "outside.txt") {
+		t.Errorf("claim staged unrelated root change:\n%s", staged)
+	}
+	if n := chartrtest.Git(t, repo, "rev-list", "--count", "HEAD"); n != "2" {
+		t.Errorf("commits after nested claim = %s, want 2 (baseline + claim)", n)
+	}
+	msg := chartrtest.Git(t, repo, "log", "-1", "--format=%B")
+	if !strings.Contains(msg, "Claim "+rel) || !strings.Contains(msg, "Session: "+sp.SessionID) {
+		t.Errorf("claim commit does not use the root-relative ticket path or session:\n%s", msg)
+	}
+
+	tk := findTicket(t, findMap(t, findSpace(t, h.Snapshot(ctx(t)), resp.ID), "widget"), 1)
+	if tk.Status != "claimed" || tk.ClaimedBy != sp.SessionID {
+		t.Errorf("nested ticket claim = {status:%s by:%q}, want {claimed %q}", tk.Status, tk.ClaimedBy, sp.SessionID)
+	}
+}
+
 // A spawn that names no agent is refused (ticket 04) — there is no binding to fall
 // back to any more — and the refusal blocks nothing else: no claim is written, the
 // ticket stays open with no session tab, and the space is still fully usable as a


### PR DESCRIPTION
> No worries if you insta-close this, but this is a feature I leverage daily in other harnesses/multiplexers and hope you take it under consideration

## Problem
My company uses a monorepo for the entirety of our various internal and external systems. In claude, codex, etc I typically work from a subdirectory of a given system. When doing that, chartr initializes a git repo in the subdirectory breaking all understanding of the real git scenario. This allows for that pattern and matches how claude/codex behave. 


## Summary

When an operator registers a Space inside an existing Git repository, chartr
must use the repository root for Git actions. It must keep the selected
directory as the Space path for Space files and maps.

This change:

- Finds the nearest usable Git root with Git-native discovery.
- Runs `git init` only when Git confirms that no repository exists.
- Stops on other Git errors. It does not replace broken Git metadata.
- Keeps the selected Space path in the registry and API response.
- Uses the Git root for repository setup, branch state, dirty state, claim
  commits, and release commits.
- Keeps map, skill, ticket, and other Space file discovery under the Space path.
- Keeps claim and release commits limited to one ticket file.
- Resolves symlinks before making a ticket path relative to the Git root. This
  supports systems where `/var` and `/private/var` name the same directory.

## Implementation

- Added the shared `internal/gitroot` package for root discovery, safe
  no-repository classification, initialization, and Git-relative path handling.
- Updated registration to keep the Space path private from Git-root details.
- Updated branch and dirty-state reads to use the Git root.
- Updated claim, ticket release, and dead-session release commits to use the
  Git root and root-relative pathspecs.
- Added the Git-root specification, decision records, implementation map, and
  ticket answers.

## Tests

- `make check` passes.
- `make build` passes.
- `go test ./internal/server -count=1` passes.
- The new symlink-path claim test passes.
- The complete `make test` run reaches the existing terminal-process tests.
  Those tests still fail in this environment because process detection and
  terminal input behavior differ from the test harness. One existing agent
  environment test also has a timing-sensitive log assertion. The new
  Git-root server tests pass.

