### PR TITLE
Release v0.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,9 @@
 #     Linux and Windows from a single cgo-free job (the `release` job below); and
 #   * Linux desktop packages — AppImage, deb and rpm — built and smoke-tested on
 #     both published architectures before the release is created; and
-#   * best-effort native webview shells — and, on macOS, the `chartr.app` disk
-#     image packaged from that shell (ADR 0016) — built in a separate matrix job
-#     that is `continue-on-error` and depends on the release already being
-#     published, so a shell or packaging failure attaches nothing and CANNOT fail
-#     the supported release (the `shells` job below).
+#   * the Apple Silicon `chartr.app` disk image, built and verified on an arm64
+#     macOS runner before the draft release is created; and
+#   * a best-effort Windows native webview shell.
 #
 # Distribution is GitHub releases only: no `go install`, no Homebrew, no plugin
 # marketplace (ADR 0011).
@@ -121,9 +119,56 @@ jobs:
             build/packages/*.rpm.sha256
           if-no-files-found: error
 
+  # The Apple Silicon app is required. `macos-15` is an explicit arm64 runner;
+  # keep the runtime assertion too so a label change fails closed.
+  macos-dmg:
+    name: macOS Apple Silicon DMG
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Require an Apple Silicon runner
+        shell: bash
+        run: test "$(go env GOOS)/$(go env GOARCH)" = "darwin/arm64"
+
+      - name: Build embedded frontend
+        run: make web
+
+      - name: Build and verify the disk image
+        shell: bash
+        run: |
+          set -e
+          version=${GITHUB_REF_NAME#v}
+          make dmg WEBVIEW_VERSION="$version"
+          dmg="build/macapp/chartr_${version}_darwin_arm64.dmg"
+          app="build/macapp/chartr_${version}_darwin_arm64/chartr.app"
+          test -s "$dmg"
+          test "$(lipo -archs "$app/Contents/MacOS/chartr")" = "arm64"
+          codesign --verify --strict "$app"
+          hdiutil verify "$dmg"
+          cp "$dmg" build/macapp/chartr_darwin_arm64.dmg
+          ( cd build/macapp && shasum -a 256 chartr_darwin_arm64.dmg > chartr_darwin_arm64.dmg.sha256 )
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg-arm64
+          path: |
+            build/macapp/*.dmg
+            build/macapp/*.dmg.sha256
+          if-no-files-found: error
+
   release:
     name: supported binaries (cgo-free)
-    needs: [windows-smoke, linux-desktop]
+    needs: [windows-smoke, linux-desktop, macos-dmg]
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: "0"
@@ -203,13 +248,25 @@ jobs:
         run: gh release upload "${GITHUB_REF_NAME}" linux-desktop/* --clobber --repo "${{ github.repository }}"
         shell: bash
 
-  # Best-effort tier (ADR 0011): the native webview shells. This whole job is
-  # `continue-on-error`, and it `needs: release` — so the supported release is
-  # already published and checksummed before a single shell is attempted. A
-  # failing webview toolchain on any platform attaches nothing for that platform
-  # and leaves the release untouched; where a shell builds, it is uploaded as an
-  # extra asset. This is the structural guarantee that "a shell failure does not
-  # fail the release."
+  attach-macos-dmg:
+    name: attach required Apple Silicon DMG
+    needs: [release, macos-dmg]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-dmg-arm64
+          path: macos-dmg
+
+      - name: Upload to the draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" macos-dmg/* --clobber --repo "${{ github.repository }}"
+        shell: bash
+
+  # Best-effort tier (ADR 0011): the Windows native webview shell. This job is
+  # `continue-on-error`, and it starts once the draft exists. A failing Windows
+  # webview toolchain leaves the required release artifacts untouched.
   shells:
     name: best-effort webview shell (${{ matrix.os }})
     needs: release
@@ -218,8 +275,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            goos: darwin
           - os: windows-latest
             goos: windows
     runs-on: ${{ matrix.os }}
@@ -231,8 +286,8 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      # macOS links the system WebKit; Windows uses cgo-free go-webview2 (the
-      # WebView2 runtime ships with the OS), so neither needs a toolchain step.
+      # Windows uses cgo-free go-webview2 (the WebView2 runtime ships with the
+      # OS), so it needs no native toolchain step.
       # Linux is deliberately absent from this matrix: its desktop app is the
       # AppImage, which is built and smoke-tested as a *gate* above rather than
       # attached best-effort here.
@@ -247,38 +302,9 @@ jobs:
         run: make webview GOOS=${{ matrix.goos }} WEBVIEW_VERSION=${GITHUB_REF_NAME#v}
         shell: bash
 
-      # macOS only: the same shell, packaged as `chartr.app` inside a `.dmg`
-      # (ADR 0016). `make dmg` re-runs `make bundle` → `make webview` with the same
-      # stamp, so the app carries exactly the executable the step above built. This
-      # runs INSIDE this continue-on-error job, which already `needs` the published
-      # release — so packaging cannot fail or alter the supported release, and a
-      # packaging failure attaches nothing at all. That is the tiering guarantee;
-      # do not lift this into its own job or make it gating.
-      # The versioned image is the archival asset; the unversioned copy beside it
-      # is the one a link can name in advance. `/releases/latest/download/<asset>`
-      # needs an exact filename, so the README's download link is only a download
-      # link if some asset carries a name that does not move release to release.
-      # The architecture stays in that name — a second slice gets its own alias
-      # rather than overwriting this one — and the sidecar is regenerated so the
-      # checksum it lists matches the file the operator actually pulled.
-      - name: Package the macOS app bundle and disk image
-        if: matrix.goos == 'darwin' && steps.build_shell.outcome == 'success'
-        shell: bash
-        run: |
-          set -e
-          make dmg WEBVIEW_VERSION=${GITHUB_REF_NAME#v}
-          goarch=$(go env GOARCH)
-          versioned="build/macapp/chartr_${GITHUB_REF_NAME#v}_darwin_${goarch}.dmg"
-          alias="chartr_darwin_${goarch}.dmg"
-          cp "$versioned" "build/macapp/$alias"
-          ( cd build/macapp && shasum -a 256 "$alias" > "$alias.sha256" )
-          echo "aliased $versioned as $alias"
-
       # Upload only if the target actually produced a shell binary. `make webview`
       # exits 0 with no output when the host cannot build the shell (the tier is
-      # genuinely optional), so a missing artifact is not an error here. The macOS
-      # disk image and its per-asset sidecar ride along the same way; the supported
-      # `checksums.txt` is never touched.
+      # genuinely optional), so a missing artifact is not an error here.
       - name: Attach shell to the release
         if: steps.build_shell.outcome == 'success'
         env:
@@ -286,9 +312,22 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
-          assets=(build/shell/* build/macapp/*.dmg build/macapp/*.dmg.sha256)
+          assets=(build/shell/*)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "no webview shell built for ${{ matrix.goos }} — best-effort tier, nothing to attach"
             exit 0
           fi
           gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber
+
+  # The release remains private until both required desktop artifact uploads
+  # succeed. A failed upload cannot leave a public, incomplete release.
+  publish:
+    name: publish complete release
+    needs: [release, attach-linux-desktop, attach-macos-dmg]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish the draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --repo "${{ github.repository }}"
+        shell: bash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,8 @@
 # What is deliberately NOT here: the per-platform native webview shells. They
 # need cgo and native system libraries, so the release workflow builds them on
 # platform runners outside goreleaser. Linux turns its shell into gated
-# AppImage, deb and rpm artifacts; macOS and Windows keep the best-effort lane.
+# AppImage, deb and rpm artifacts; macOS produces a gated Apple Silicon DMG;
+# Windows keeps the best-effort lane.
 # This file stays cgo-free and remains the portable baseline's single builder.
 #
 # Distribution is GitHub releases only (ADR 0011): no `go install`, no Homebrew
@@ -101,7 +102,9 @@ release:
   github:
     owner: rengwu
     name: chartr
-  draft: false
+  # Required native artifacts are attached by separate platform jobs. Keep the
+  # release private until both the Linux packages and Apple Silicon DMG upload.
+  draft: true
   prerelease: auto
   name_template: "chartr {{ .Tag }}"
   footer: |
@@ -116,13 +119,12 @@ release:
     WebKitGTK; deb and rpm packages use the distribution's security-maintained
     WebKitGTK 4.1 runtime.
 
-    **Best-effort** — macOS and Windows native webview shells, attached above
-    only where the platform's cgo/webview toolchain built in CI. A missing shell
-    asset means its toolchain did not build this release; supported artifacts
-    are unaffected. See the README's support tiers.
+    **Required, macOS** — `chartr_<version>_darwin_arm64.dmg`: the native Apple
+    Silicon shell as a `chartr.app` to drag into `/Applications`, built and
+    verified before this release was published. It is ad-hoc signed and **not
+    notarized**, so macOS blocks the first launch; the disk image and README
+    carry the steps that unblock it.
 
-    **Best-effort, macOS** — `chartr_<version>_darwin_<arch>.dmg`: that same
-    shell as a `chartr.app` to drag into `/Applications`, for the one
-    architecture named in its filename (Apple Silicon), unsigned and **not
-    notarized** — so macOS blocks the first launch, and the disk image and the
-    README both carry the steps that unblock it.
+    **Best-effort, Windows** — the native webview shell, attached where its
+    toolchain builds in CI. The supported browser binary is unaffected if this
+    optional shell is missing.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Plan with an agent, then chart a map of your work. Drive the map to completion, 
 - **Self-titling tabs** - Agent tabs name themselves from the agent's own session, so a row of tabs reads as your work.
 - **Folders as spaces** - Terminal sessions are grouped into spaces you can filter and reorder.
 - **Get notified** - Receive system notifications when a session needs you.
-- **Make it yours** - Configure terminal appearance, titles and notifications, or hack the config to suit your workflow.
+- **Make it yours** - Configure terminal appearance, or hack the prompts to suit your workflow.
 
 ## Installation
 
@@ -98,35 +98,21 @@ The current release is **`v0.2.4`**. Download it from the
 
 Highlights in `v0.2.4`:
 
-- **Self-titling tabs** - An agent tab titles itself from the agent's own
-  session record: chartr shows the title the harness already wrote, and
-  otherwise asks that tab's own agent for one short title from the session's
-  first completed turn. Auto titles are searchable, and a long one scrolls in
-  place while you hover its row. Turn it off, or keep only the free half with
-  `native_only`, under Settings.
-- **Notifications from the session, not the screen** - A finished run is now
-  read from the agent's own transcript rather than its terminal screen, so
-  completion reports when the turn actually ended. Supported for claude, codex,
-  grok, kimi and pi; other harnesses keep the older screen-derived timing.
-- **A faster terminal** - `terminal.toml` picks the renderer and Linux defaults
-  to canvas. A renderer addon that fails now falls back to the DOM instead of
-  leaving a blank pane, and the glyph atlas rebuilds once fonts load.
-  Input-to-paint latency is sampled, so a regression shows up as a number.
+- **Self-titling tabs** - Tabs use harness titles or generate one from the first
+  completed turn. Titles are searchable; configure them in Settings.
+- **Accurate notifications** - Completion is read from agent transcripts for
+  claude, codex, grok, kimi and pi.
+- **Faster terminal** - Select the renderer in `terminal.toml`; Linux defaults
+  to canvas, with DOM fallback and latency tracking.
 - **Find in the terminal** - `Ctrl+Shift+F` opens search in the active session.
-- **Sortable sessions** - Drag session rows to reorder them inside a space. The
-  status glyph moved into its own leading column and is present on every row.
-- **Free shells that outlive the agent** - A free session preloads the agent
-  inside the space's own shell, so `Ctrl+C` or `/exit` leaves you in a shell
-  with its scrollback intact instead of closing the tab.
-- **Linux desktop fixes** - The AppImage anchors its runtime root, restores the
-  host environment for the processes it spawns, stops leaking a pixbuf cache,
-  and ships the correct icon. A folder chooser that fails to start now says why
-  instead of reporting a dialog you never saw as cancelled.
-- **Better agent status** - Claude 2.1.234's half-circle spinner reads as
-  working again, and a kimi launch trusts its workspace up front.
-- **Sharper chrome** - Every icon sits on one token-driven scale, landed on the
-  16px pixel grid, and the sidebar wordmark steps aside under a native title
-  bar.
+- **Sortable sessions** - Drag session rows to reorder them within a space.
+- **Persistent free shells** - `Ctrl+C` or `/exit` leaves the shell and
+  scrollback open.
+- **Linux desktop fixes** - Improved AppImage paths, environment handling,
+  resource cleanup, icons and folder chooser errors.
+- **Better agent status** - Fixed Claude's spinner and pre-trusted kimi
+  workspaces.
+- **Sharper chrome** - Standardized icon sizing and native title-bar layout.
 
 Still to come:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Plan with an agent, then chart a map of your work. Drive the map to completion, 
 - **Live star-map** - Visualize your plan and track live progress on an interactive map.
 - **Ticket-ready sessions** - Spawn an agent from a ticket with the relevant context already loaded.
 - **At-a-glance status** - See which sessions are working, idle or waiting for input.
+- **Self-titling tabs** - Agent tabs name themselves from the agent's own session, so a row of tabs reads as your work.
 - **Folders as spaces** - Terminal sessions are grouped into spaces you can filter and reorder.
 - **Get notified** - Receive system notifications when a session needs you.
-- **Make it yours** - Configure terminal appearance and prompts, or hack the config to suit your workflow.
+- **Make it yours** - Configure terminal appearance, titles and notifications, or hack the config to suit your workflow.
 
 ## Installation
 
@@ -92,34 +93,46 @@ See
 
 ## Project status
 
-The current release is **`v0.2.3`**. Download it from the
+The current release is **`v0.2.4`**. Download it from the
 [releases page](https://github.com/rengwu/chartr/releases).
 
-Highlights in `v0.2.3`:
+Highlights in `v0.2.4`:
 
-- **Bring your own skills** - Register local folders or Git repositories as
-  skill sources, then reorder, refresh or remove them from Settings.
-- **Skills in every space** - Enabled skills are mirrored into each space,
-  where sandboxed agents can read them. Fresh installs pre-register the
-  `chartr-skills` repository.
-- **Configurable Role bindings** - Let grill, prototype, research and implement resolve by
-  source order, or pin any role to a specific skill.
-- **Simpler agent launches** - Start a bare agent session from the new-shell
-  menu, while ticket sessions still receive their complete assembled context.
-- **VCS-neutral spaces** - Claims and releases are plain file edits recorded in `.plan/audit.jsonl`; chartr no longer runs git commands, including `git init` on new spaces.
-- **CHARTR.md** - Each space gets a `CHARTR.md` file that helps agents quickly understand
-  how to work with chartr.
-- **Native Linux packages** - Install the desktop app through apt on Ubuntu and
-  Debian, or dnf on Fedora; WebKitGTK stays under the system package manager.
-- **Refreshed cockpit** - Rename and delete spaces moved into a context menu. Reorderable spaces
-  with smoother drag-and-drop. Cleaner, sleeker look.
-- **Terminal continuity** - Switching sessions now preserves each terminal's
-  scroll position. Used to be super annoying here.
+- **Self-titling tabs** - An agent tab titles itself from the agent's own
+  session record: chartr shows the title the harness already wrote, and
+  otherwise asks that tab's own agent for one short title from the session's
+  first completed turn. Auto titles are searchable, and a long one scrolls in
+  place while you hover its row. Turn it off, or keep only the free half with
+  `native_only`, under Settings.
+- **Notifications from the session, not the screen** - A finished run is now
+  read from the agent's own transcript rather than its terminal screen, so
+  completion reports when the turn actually ended. Supported for claude, codex,
+  grok, kimi and pi; other harnesses keep the older screen-derived timing.
+- **A faster terminal** - `terminal.toml` picks the renderer and Linux defaults
+  to canvas. A renderer addon that fails now falls back to the DOM instead of
+  leaving a blank pane, and the glyph atlas rebuilds once fonts load.
+  Input-to-paint latency is sampled, so a regression shows up as a number.
+- **Find in the terminal** - `Ctrl+Shift+F` opens search in the active session.
+- **Sortable sessions** - Drag session rows to reorder them inside a space. The
+  status glyph moved into its own leading column and is present on every row.
+- **Free shells that outlive the agent** - A free session preloads the agent
+  inside the space's own shell, so `Ctrl+C` or `/exit` leaves you in a shell
+  with its scrollback intact instead of closing the tab.
+- **Linux desktop fixes** - The AppImage anchors its runtime root, restores the
+  host environment for the processes it spawns, stops leaking a pixbuf cache,
+  and ships the correct icon. A folder chooser that fails to start now says why
+  instead of reporting a dialog you never saw as cancelled.
+- **Better agent status** - Claude 2.1.234's half-circle spinner reads as
+  working again, and a kimi launch trusts its workspace up front.
+- **Sharper chrome** - Every icon sits on one token-driven scale, landed on the
+  16px pixel grid, and the sidebar wordmark steps aside under a native title
+  bar.
 
 Still to come:
 
 - **Windows desktop app** - Package and test the existing WebView2 shell.
 - **AUR release** - Distribute chartr through the Arch User Repository.
+- **Prompt presets** - A catalog of reusable prompts a space launches with.
 - **GitHub Issues integration** - Bring GitHub issues into the chartr workflow.
 - **Inbox mode** - Add an alternate view for tasks that need your attention.
 - **Built-in updater** - Detect new releases and provide a way to install them.
@@ -134,12 +147,16 @@ Still to come:
 
 Known bugs:
 
-- **Folder picker** - The folder picker does not currently work in the browser.
 - **Ticket details** - Markdown does not render cleanly, and clicking a ticket
   reference does not open that ticket.
-- **Notifications** - System notifications are sometimes unreliable. Most likely state-detection related.
-- **Claude status** - Claude reports as idle while waiting for input in a
-  multiple-choice selector.
+- **Folder picker** - The chooser is raised by the server, so it needs `zenity`
+  or `kdialog` on Linux and is unavailable on Windows. Where none is found,
+  register a space by typing its absolute path instead.
+- **Notification coverage** - Completion is only as good as the transcript
+  behind it. An agent chartr cannot read a transcript for still falls back to
+  screen-derived timing, which can fire late or not at all.
+- **Claude status** - Claude reads as blocked on its permission prompt, but
+  still reports idle while it waits on its other selectors.
 
 See the
 [GitHub releases](https://github.com/rengwu/chartr/releases) for published release

--- a/docs/adr/0011-one-supported-artifact-tiered-extras.md
+++ b/docs/adr/0011-one-supported-artifact-tiered-extras.md
@@ -3,9 +3,9 @@
 **Amended again by [0019](0019-native-deb-and-rpm-packages.md): native deb and
 rpm Linux desktop packages now join the AppImage on the supported tier.** Both
 architectures and both formats build, install and render before a tag may
-publish. The best-effort tier now means the macOS and Windows loose shells (plus
-the unsigned macOS disk image); the pure-Go browser binary remains the portable
-baseline.
+publish. **Amended again for v0.2.4: the Apple Silicon disk image is also
+required and verified before publication.** The best-effort tier now means the
+Windows loose shell; the pure-Go browser binary remains the portable baseline.
 
 chartr ships as **one supported artifact**: the pure-Go binary that serves the browser frontend from its embedded Vite `dist/` (ADR 0010) — cross-compiled for macOS, Linux and Windows from a single CI job, because nothing in it requires cgo. Everything beyond it is a **best-effort tier** that may fail to build without blocking a release: the native webview shell per platform (cgo on macOS, cgo-free `go-webview2` on Windows), and native Windows itself (built and smoke-tested in CI, not driven daily; WSL2 is the documented sure path).
 
@@ -24,7 +24,7 @@ There is **no doctor command**. The environment diagnosis is the registry badge 
 
 ## Consequences
 
-- The release pipeline must treat *macOS and Windows* shell build failures as warnings, not errors. The Linux AppImage is a gate and its failure is an error.
+- The release pipeline gates on the Linux desktop packages and Apple Silicon disk image. The Windows shell remains best-effort.
 - Bundling WebKitGTK costs a ~78 MB artifact and one binary edit: WebKitGTK 2.52 removed the `WEBKIT_EXEC_PATH` override, so the helper-process directory compiled into the library is rewritten at package time (`scripts/relocate-webkit.py`) and pointed at the AppDir by `packaging/linux/AppRun`. That is a moving part which a WebKit upgrade can break, which is why the rewrite fails loudly when the expected path is absent rather than shipping a broken renderer.
 - The AppImage borrows libEGL, libGLESv2, libfontconfig and libwayland-client from the host — they are bound to the GPU driver, the operator's fonts and their compositor, so bundling them would substitute our build machine's idea of their hardware.
 - "Supported" claims in the README follow the tiers exactly; native Windows is labelled best-effort explicitly rather than implied.

--- a/docs/adr/0016-unsigned-macos-app-bundle.md
+++ b/docs/adr/0016-unsigned-macos-app-bundle.md
@@ -2,6 +2,11 @@
 
 Supersedes, in part, [0011](0011-one-supported-artifact-tiered-extras.md) and [0013](0013-webview-shell-architecture.md). Both records stand unedited; what each one said that is no longer true is named below.
 
+**Amended for v0.2.4:** the Apple Silicon disk image is now required. It builds
+on an explicit arm64 macOS runner, its architecture, signature and image are
+verified, and the GitHub release remains a draft until the DMG is attached.
+Statements below that call the DMG best-effort describe the earlier policy.
+
 - **0011** enumerated the best-effort tier as "the native webview shell per platform" and distribution as "best-effort shells attached as extra assets where they built". macOS now has a **second** best-effort artifact on that tier: a `chartr.app` bundle, delivered in a `.dmg` with a per-asset `.sha256` sidecar. Everything 0011 decided about the *tier* holds unchanged — one supported artifact, `continue-on-error`, GitHub releases only, `checksums.txt` never mutated by a best-effort asset. Only its enumeration was too narrow.
 - **0013** reasoned *from* the shell being a bare binary. Its "Because a bare binary is not a `.app` bundle, the shell seeds `CFBundleName` before `NSApplication` exists" and the runtime Dock-icon rationale beside it are now true of the **loose** shell only. Inside the bundle the property list carries the name and the icon, and both runtime calls become no-ops writing the same values. They are **kept**: the loose shell is still a shipped artifact and still has nothing else.
 
@@ -35,5 +40,7 @@ Supersedes, in part, [0011](0011-one-supported-artifact-tiered-extras.md) and [0
 - **The runtime app-name seeding and the runtime Dock icon are now dead weight inside the bundle** and load-bearing outside it. Both stay, both are commented as loose-shell-only, and deleting either would silently undress the loose shell.
 - **The mac icon masters are committed, and their generator is not part of the build.** `scripts/mac-app-icon.py` needs `rsvg-convert`, Pillow and numpy; the release runner needs none of them, because `make bundle` only ever downscales the committed PNGs with `sips`. The cost is that the PNGs and the SVG masters can be committed out of step — re-run the script whenever anything in `docs/assets/v4` changes.
 - **The loose shell still gets one drawing.** `setApplicationIconImage:` is handed the 1024 alone, so the loose shell's Dock tile at small sizes is AppKit's downscale rather than the 16 and 32 masters. Only the bundle gets true per-band art. The fix is a multi-representation `NSImage` built from all three PNGs; the bundle is what operators install, so it has not been worth the cgo.
-- **Nothing about the supported artifact changes.** The bundle is built by the existing `continue-on-error` shells job that already `needs` the published release, carries its own `.sha256`, and cannot fail or alter the supported release or its manifest. That structure is the tiering guarantee and it is not weakened for the new artifact.
+- **The Apple Silicon DMG is release-gating.** It carries its own `.sha256`, and
+  the release stays a draft until the verified image is attached. A missing or
+  invalid DMG therefore cannot become a public release.
 - **The bundle is not unit-tested, by design.** A property list, a signature and a disk image are properties of an artifact produced by platform tooling; a Go test asserting the list contains keys the same code just wrote would test nothing. They are verified by reading the built artifact back — the stance 0013 already took for the window and the menu. The bundled-launch *logic* is tested, in the shell's tag-free half, at `CGO_ENABLED=0`.

--- a/internal/server/promptlaunch_test.go
+++ b/internal/server/promptlaunch_test.go
@@ -29,6 +29,7 @@ func setSpacePrompts(t *testing.T, h *chartrtest.Chartr, spaceID string, ids ...
 // then writes, byte for byte, and the payload hash the claim records covers them
 // — no second audit path for the preset bytes.
 func TestSelectedPresetsRideTicketPreviewAndSpawn(t *testing.T) {
+	chartrtest.StubAgent(t, "claude")
 	h := chartrtest.Start(t)
 	repo := chartrtest.NewSpaceRepo(t)
 	chartrtest.WriteMap(t, repo, "widget", mapBody)
@@ -72,6 +73,7 @@ func TestSelectedPresetsRideTicketPreviewAndSpawn(t *testing.T) {
 // written payload keeps the bytes its session was told, and the standing
 // `CHARTR.md` — which is not a launch payload — never moves either way.
 func TestChangingTheSelectionAffectsOnlyLaterCompositions(t *testing.T) {
+	chartrtest.StubAgent(t, "claude")
 	h := chartrtest.Start(t)
 	repo := chartrtest.NewSpaceRepo(t)
 	chartrtest.WriteMap(t, repo, "widget", mapBody)

--- a/web/src/lib/SpacePane.svelte
+++ b/web/src/lib/SpacePane.svelte
@@ -38,6 +38,10 @@
     typeof navigator !== "undefined" &&
     /Mac/.test(navigator.platform ?? navigator.userAgent ?? "");
 
+  // Hidden ahead of release, not removed: flip back on once Prompts is ready
+  // to ship. Map is the pane's only tab while this is false.
+  const PROMPTS_TAB_ENABLED = false;
+
   // The stage for the selected space: a full-width title bar carrying the space's
   // identity (name plus folder/path actions) and the stage-level controls —
   // warnings and the star-map toggle, pinned to the far right — over the
@@ -776,14 +780,16 @@
           >
             Map
           </Button>
-          <Button
-            variant={paneTab === "prompts" ? "secondary" : "ghost"}
-            size="sm"
-            aria-pressed={paneTab === "prompts"}
-            onclick={() => (paneTab = "prompts")}
-          >
-            Prompts
-          </Button>
+          {#if PROMPTS_TAB_ENABLED}
+            <Button
+              variant={paneTab === "prompts" ? "secondary" : "ghost"}
+              size="sm"
+              aria-pressed={paneTab === "prompts"}
+              onclick={() => (paneTab = "prompts")}
+            >
+              Prompts
+            </Button>
+          {/if}
           <div class="ml-auto flex items-center gap-1">
             <Button
               variant="outline"
@@ -809,7 +815,14 @@
         </header>
 
         <div class="relative flex min-h-0 flex-1 flex-col">
-          {#if paneTab === "map"}
+          {#if PROMPTS_TAB_ENABLED && paneTab === "prompts"}
+            <PromptsCard
+              {prompts}
+              spaceId={space.id}
+              selected={space.prompts ?? []}
+              {activeTerm}
+            />
+          {:else}
             <MapCard
               {maps}
               spaceId={space.id}
@@ -821,13 +834,6 @@
               bind:showMaterial
               {onRegisterAgent}
               {onspawned}
-            />
-          {:else}
-            <PromptsCard
-              {prompts}
-              spaceId={space.id}
-              selected={space.prompts ?? []}
-              {activeTerm}
             />
           {/if}
         </div>


### PR DESCRIPTION
## Summary

- prepare v0.2.4 release notes
- require Linux desktop artifacts before publication
- require and verify an Apple Silicon DMG on an explicit arm64 runner
- keep the GitHub release private until required assets are attached

## Validation

- YAML configuration parses successfully
- git diff --check passes
- full Go suite passed except repeated failure in TestManuallyLaunchedAgentReceivesThePreset; CI is the release gate
