### PR TITLE
Fix Linux AppImage window class

### DIFF
--- a/cmd/webview/icon_linux.go
+++ b/cmd/webview/icon_linux.go
@@ -31,11 +31,6 @@ package main
 static void wfSetAppIcon(void *window, const void *bytes, int len) {
   GtkWindow *gtk_window = GTK_WINDOW(window);
 
-  // X11 shells associate the window with chartr.desktop through WM_CLASS.
-  // The explicit value also avoids inheriting an AppImage filename as the
-  // class on runtimes which derive it from argv[0].
-  gtk_window_set_wmclass(gtk_window, "chartr", "chartr");
-
   // A GdkWindow exists after realization. On Wayland its application ID is
   // the only supported way for the compositor to associate this surface with
   // chartr.desktop and therefore with the icon bundled in the AppImage.

--- a/cmd/webview/menu_linux.go
+++ b/cmd/webview/menu_linux.go
@@ -3,9 +3,10 @@
 package main
 
 /*
-#cgo pkg-config: glib-2.0
+#cgo pkg-config: gtk+-3.0
 
 #include <glib.h>
+#include <gdk/gdk.h>
 #include <stdlib.h>
 
 static void wfSetAppName(const char *name) {
@@ -14,6 +15,7 @@ static void wfSetAppName(const char *name) {
   // they match chartr.desktop regardless of the AppImage's filename.
   g_set_prgname(name);
   g_set_application_name(name);
+  gdk_set_program_class(name);
 }
 */
 import "C"

--- a/scripts/smoke-appimage.sh
+++ b/scripts/smoke-appimage.sh
@@ -91,6 +91,7 @@ docker run --rm -v "$(realpath "$APPIMAGE")":/chartr.AppImage:ro "$IMAGE" bash -
 	WINDOW_ID=$(xdotool search --onlyvisible --name "chartr" 2>/dev/null | head -n 1)
 	[ -n "$WINDOW_ID" ] || fail "could not find the chartr window"
 	PROPS=$(xprop -id "$WINDOW_ID" WM_CLASS _NET_WM_ICON)
+	echo "$PROPS"
 	echo "$PROPS" | grep -q "WM_CLASS(STRING) = \"chartr\", \"chartr\"" || \
 		fail "the window WM_CLASS does not match chartr.desktop"
 	echo "$PROPS" | grep -q "_NET_WM_ICON(CARDINAL) =" || \


### PR DESCRIPTION
## Summary

- set the GDK program class before GTK creates the native window
- stop calling the ignored post-realization WM_CLASS setter
- print X11 properties when AppImage desktop integration smoke fails

## Context

The v0.2.4-rc.1 AppImages built successfully on amd64 and arm64, but both smoke tests failed because GTK rejected gtk_window_set_wmclass after window realization. The Apple Silicon DMG gate passed.

## Validation

- native Linux webview shell compiles locally
- release RC will rerun both AppImage screenshot smoke tests
