### PR TITLE
Unblock the v0.2.4 release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Static checks (go vet + svelte-check)
         run: make check
 
+      - name: Shell script syntax
+        run: bash -n scripts/*.sh
+
       - name: Go tests
         run: make test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,10 +230,22 @@ jobs:
         shell: bash
         run: |
           set -e
+          # upload-artifact roots the artifact at the common ancestor of its
+          # path globs, so the download arrives split across appimage/ and
+          # packages/ rather than flat. v0.2.3 shipped with no Linux assets at
+          # all because of that: every `ls` below missed, every arch was
+          # skipped without complaint, and the upload then choked on a
+          # directory in its glob. Flatten first, and fail loudly on a miss.
+          find linux-desktop -mindepth 2 -type f -exec mv -t linux-desktop {} +
+          find linux-desktop -mindepth 1 -type d -empty -delete
           for arch in amd64 arm64; do
             for extension in AppImage deb rpm; do
               versioned=$(ls linux-desktop/chartr_*_linux_${arch}.${extension} 2>/dev/null | head -1) || true
-              [ -n "$versioned" ] || continue
+              if [ -z "$versioned" ]; then
+                echo "no chartr_*_linux_${arch}.${extension} among the built artifacts:" >&2
+                ls -R linux-desktop >&2
+                exit 1
+              fi
               alias="linux-desktop/chartr_linux_${arch}.${extension}"
               cp "$versioned" "$alias"
               ( cd linux-desktop && sha256sum "chartr_linux_${arch}.${extension}" > "chartr_linux_${arch}.${extension}.sha256" )

--- a/scripts/smoke-appimage.sh
+++ b/scripts/smoke-appimage.sh
@@ -85,7 +85,7 @@ docker run --rm -v "$(realpath "$APPIMAGE")":/chartr.AppImage:ro "$IMAGE" bash -
 		fail "WebKit reported an internal error"
 	fi
 
-	# The X11 identity is the runtime half of desktop integration. GTK's resource
+	# The X11 identity is the runtime half of desktop integration. The GTK resource
 	# name is lowercase and its resource class is conventionally title-cased;
 	# StartupWMClass uses the latter so a real desktop resolves the bundled icon.
 	# Bare Xvfb has no window manager, so _NET_WM_ICON is diagnostic only here.

--- a/scripts/smoke-native-package.sh
+++ b/scripts/smoke-native-package.sh
@@ -67,7 +67,10 @@ docker run --rm \
 	test -x /usr/bin/chartr
 	test -f /usr/share/applications/io.github.rengwu.chartr.desktop
 	test -f /usr/share/metainfo/io.github.rengwu.chartr.metainfo.xml
-	test -f /usr/share/icons/hicolor/512x512/apps/chartr.png
+	# The icon bands ship as SVG masters (ADR 0016), not a single 512 PNG.
+	test -f /usr/share/icons/hicolor/16x16/apps/chartr.svg
+	test -f /usr/share/icons/hicolor/32x32/apps/chartr.svg
+	test -f /usr/share/icons/hicolor/scalable/apps/chartr.svg
 	chartr --version | grep -F "chartr shell ${EXPECTED_VERSION} "
 
 	export XDG_RUNTIME_DIR=/tmp/xdg


### PR DESCRIPTION
## Summary

Three release-blocking defects, two of them latent behind the first.

- **AppImage smoke was unparseable.** An apostrophe in a comment (`GTK's`) closed the single-quoted container script early. RC3 rendered the cockpit at mean brightness 15/255, then exited 127 at that boundary. CI now runs `bash -n scripts/*.sh`.
- **Native-package smoke asserts an icon that is no longer shipped.** `1e45e70` moved the icon bands to SVG masters; the smoke still required `/usr/share/icons/hicolor/512x512/apps/chartr.png`. This step has not run since v0.2.3, so it would have failed the moment RC4 got past the AppImage gate.
- **The attach job silently dropped every Linux asset.** `upload-artifact` roots the artifact at the common ancestor of its path globs, so the download arrives split across `appimage/` and `packages/`, not flat. Every lookup missed, every architecture was skipped without complaint, and `gh release upload linux-desktop/*` then choked on a directory. **v0.2.3 carries no AppImage, deb or rpm asset at all** and its `/releases/latest/download/` links point at nothing. The download is now flattened first, and a missing architecture fails loudly.

## Evidence

- RC3 amd64: `screenshot: mean brightness 15/255 across 780 colours` then `exit code 127`.
- RC2 printed `WM_CLASS(STRING) = "chartr", "Chartr"`, which is what the assertion (and `StartupWMClass`) now expect, so that check should pass once it is reachable.
- v0.2.3 run 31629892889: `read linux-desktop/appimage: is a directory`; `gh release view v0.2.3` lists no Linux desktop assets.
- The alias step was replayed locally against the real split layout: 6 aliases created, 24 files, zero directories left in the upload set.

## Not verified here

The deb/rpm smoke and the attach job cannot run outside CI (no Docker on this machine). These fixes are read from the artifact layout and the nfpm payload rather than from a green run, so RC4 is still the real test.
